### PR TITLE
Fix ListTaskCommand to only display patients with tasks

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListTaskCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.address.model.Model;
 
@@ -19,7 +18,7 @@ public class ListTaskCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setTaskListFlag(true);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredPersonList(p -> !(p.getTasks().isEmpty()));
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }


### PR DESCRIPTION
Fix previous bug where patients with empty task lists are also displayed with the `listTask` command.