### PR TITLE
Fix person and task list string format

### DIFF
--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -57,8 +57,6 @@ public class Person {
     }
 
     public TaskList getTasks() {
-        // find some other place to make tasklist immutable with Collections.unmodifiableList
-        // since can't use if encapsualted in a TaskList class
         return tasks;
     }
 
@@ -116,22 +114,22 @@ public class Person {
     public String toString() {
         final StringBuilder builder = new StringBuilder();
         builder.append(getName())
-                .append("; Phone: ")
+                .append("\nPhone: ")
                 .append(getPhone())
-                .append("; Email: ")
+                .append("\nEmail: ")
                 .append(getEmail())
-                .append("; Address: ")
+                .append("\nAddress: ")
                 .append(getAddress());
 
         TaskList tasks = getTasks();
         if (!tasks.isEmpty()) {
-            builder.append("; Tasks: ")
-                    .append(tasks.toString());
+            builder.append("\nTasks:")
+                    .append(tasks);
         }
 
         Set<Tag> tags = getTags();
         if (!tags.isEmpty()) {
-            builder.append("; Tags: ");
+            builder.append("\nTags: ");
             tags.forEach(builder::append);
         }
         return builder.toString();

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -129,7 +129,7 @@ public class Person {
 
         Set<Tag> tags = getTags();
         if (!tags.isEmpty()) {
-            builder.append("Tags: ");
+            builder.append("\nTags: ");
             tags.forEach(builder::append);
         }
         return builder.toString();

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -123,13 +123,13 @@ public class Person {
 
         TaskList tasks = getTasks();
         if (!tasks.isEmpty()) {
-            builder.append("\nTasks:")
+            builder.append("\nTasks:\n")
                     .append(tasks);
         }
 
         Set<Tag> tags = getTags();
         if (!tags.isEmpty()) {
-            builder.append("\nTags: ");
+            builder.append("Tags: ");
             tags.forEach(builder::append);
         }
         return builder.toString();

--- a/src/main/java/seedu/address/model/task/TaskList.java
+++ b/src/main/java/seedu/address/model/task/TaskList.java
@@ -61,10 +61,19 @@ public class TaskList {
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
-        internalTaskList.forEach(t -> builder.append(internalTaskList.indexOf(t) + 1)
-                .append(". ")
-                .append(t)
-                .append("\n"));
+        internalTaskList.forEach(t -> {
+            int index = internalTaskList.indexOf(t);
+                if (index == 0) {
+                    builder.append(index + 1)
+                            .append(". ")
+                            .append(t);
+                } else {
+                    builder.append("\n")
+                            .append(index + 1)
+                            .append(". ")
+                            .append(t);
+                }
+        });
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/model/task/TaskList.java
+++ b/src/main/java/seedu/address/model/task/TaskList.java
@@ -63,16 +63,16 @@ public class TaskList {
         final StringBuilder builder = new StringBuilder();
         internalTaskList.forEach(t -> {
             int index = internalTaskList.indexOf(t);
-                if (index == 0) {
-                    builder.append(index + 1)
-                            .append(". ")
-                            .append(t);
-                } else {
-                    builder.append("\n")
-                            .append(index + 1)
-                            .append(". ")
-                            .append(t);
-                }
+            if (index == 0) {
+                builder.append(index + 1)
+                        .append(". ")
+                        .append(t);
+            } else {
+                builder.append("\n")
+                        .append(index + 1)
+                        .append(". ")
+                        .append(t);
+            }
         });
         return builder.toString();
     }

--- a/src/main/java/seedu/address/model/task/TaskList.java
+++ b/src/main/java/seedu/address/model/task/TaskList.java
@@ -61,10 +61,10 @@ public class TaskList {
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
-        internalTaskList.forEach(t -> builder.append("\n")
-                .append(internalTaskList.indexOf(t) + 1)
+        internalTaskList.forEach(t -> builder.append(internalTaskList.indexOf(t) + 1)
                 .append(". ")
-                .append(t));
+                .append(t)
+                .append("\n"));
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/model/task/TaskList.java
+++ b/src/main/java/seedu/address/model/task/TaskList.java
@@ -44,10 +44,16 @@ public class TaskList {
         return internalTaskList.size();
     }
 
+    /**
+     * Returns true if the task list is empty/
+     */
     public boolean isEmpty() {
         return this.internalTaskList.isEmpty();
     }
 
+    /**
+     * Returns the internal task list.
+     */
     public ArrayList<Task> getTasks() {
         return internalTaskList;
     }
@@ -55,10 +61,10 @@ public class TaskList {
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
-        internalTaskList.forEach(t -> builder.append(internalTaskList.indexOf(t) + 1)
+        internalTaskList.forEach(t -> builder.append("\n")
+                .append(internalTaskList.indexOf(t) + 1)
                 .append(". ")
-                .append(t)
-                .append(" "));
+                .append(t));
         return builder.toString();
     }
 


### PR DESCRIPTION
Closes #139 

`Person#toString()` and `TaskList#toString()` returned strings in a single-line format, which makes the output hard to read. Changed such that each task and each `Person` attribute is displayed on a new line.

`Person#toString()` returns a string with the following format:
```
NAME
Phone: PHONE
Email: EMAIL
Address: ADDRESS
Tasks:
1. TASK_1
2. TASK_2
3. TASK_3
Tags: [TAG_1][TAG_2]
``` 
`TaskList#toString()` returns a string with the following format:
```
1. TASK_1
2. TASK_2
3. TASK_3
```
