### PR TITLE
Add options-based command syntax support

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddGenericCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddGenericCommandParser.java
@@ -3,6 +3,8 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_OPTION_PATIENT_INDEX;
 
+import java.util.Optional;
+
 import seedu.address.logic.commands.AddGenericCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -23,13 +25,14 @@ public class AddGenericCommandParser implements Parser<AddGenericCommand> {
         ArgumentMultimap options = ParserUtil.parseOptions(args, PREFIX_OPTION_PATIENT_INDEX);
         args = ParserUtil.eraseOptions(args, PREFIX_OPTION_PATIENT_INDEX);
 
-        if (!options.getValue(PREFIX_OPTION_PATIENT_INDEX).isPresent()) {
+        Optional<String> patientIndex = options.getValue(PREFIX_OPTION_PATIENT_INDEX);
+
+        if (!patientIndex.isPresent()) {
             return new AddPatientCommandParser().parse(args);
         }
 
-        if (options.getValue(PREFIX_OPTION_PATIENT_INDEX).isPresent()) {
-            String patientIndex = options.getValue(PREFIX_OPTION_PATIENT_INDEX).get();
-            return new AddTaskCommandParser().parse(patientIndex + " " + args);
+        if (patientIndex.isPresent()) {
+            return new AddTaskCommandParser().parse(patientIndex.get() + " " + args);
         }
 
         throw new ParseException(ParserUtil.MESSAGE_INVALID_OPTIONS);

--- a/src/main/java/seedu/address/logic/parser/DeleteGenericCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteGenericCommandParser.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_OPTION_PATIENT_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_OPTION_TASK_INDEX;
 
+import java.util.Optional;
+
 import seedu.address.logic.commands.DeleteGenericCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -24,17 +26,15 @@ public class DeleteGenericCommandParser implements Parser<DeleteGenericCommand> 
         ArgumentMultimap options = ParserUtil.parseOptions(args, PREFIX_OPTION_PATIENT_INDEX, PREFIX_OPTION_TASK_INDEX);
         args = ParserUtil.eraseOptions(args, PREFIX_OPTION_PATIENT_INDEX, PREFIX_OPTION_TASK_INDEX);
 
-        if (options.getValue(PREFIX_OPTION_PATIENT_INDEX).isPresent()
-                && !options.getValue(PREFIX_OPTION_TASK_INDEX).isPresent()) {
-            String patientIndex = options.getValue(PREFIX_OPTION_PATIENT_INDEX).get();
-            return new DeletePatientCommandParser().parse(patientIndex + " " + args);
+        Optional<String> patientIndex = options.getValue(PREFIX_OPTION_PATIENT_INDEX);
+        Optional<String> taskIndex = options.getValue(PREFIX_OPTION_TASK_INDEX);
+
+        if (patientIndex.isPresent() && !taskIndex.isPresent()) {
+            return new DeletePatientCommandParser().parse(patientIndex.get() + " " + args);
         }
 
-        if (options.getValue(PREFIX_OPTION_PATIENT_INDEX).isPresent()
-                && options.getValue(PREFIX_OPTION_TASK_INDEX).isPresent()) {
-            String patientIndex = options.getValue(PREFIX_OPTION_PATIENT_INDEX).get();
-            String taskIndex = options.getValue(PREFIX_OPTION_TASK_INDEX).get();
-            return new DeleteTaskCommandParser().parse(patientIndex + " " + taskIndex + " " + args);
+        if (patientIndex.isPresent() && taskIndex.isPresent()) {
+            return new DeleteTaskCommandParser().parse(patientIndex.get() + " " + taskIndex.get() + " " + args);
         }
 
         throw new ParseException(ParserUtil.MESSAGE_INVALID_OPTIONS);

--- a/src/main/java/seedu/address/logic/parser/EditGenericCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditGenericCommandParser.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_OPTION_PATIENT_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_OPTION_TASK_INDEX;
 
+import java.util.Optional;
+
 import seedu.address.logic.commands.EditGenericCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -24,17 +26,15 @@ public class EditGenericCommandParser implements Parser<EditGenericCommand> {
         ArgumentMultimap options = ParserUtil.parseOptions(args, PREFIX_OPTION_PATIENT_INDEX, PREFIX_OPTION_TASK_INDEX);
         args = ParserUtil.eraseOptions(args, PREFIX_OPTION_PATIENT_INDEX, PREFIX_OPTION_TASK_INDEX);
 
-        if (options.getValue(PREFIX_OPTION_PATIENT_INDEX).isPresent()
-                && !options.getValue(PREFIX_OPTION_TASK_INDEX).isPresent()) {
-            String patientIndex = options.getValue(PREFIX_OPTION_PATIENT_INDEX).get();
-            return new EditPatientCommandParser().parse(patientIndex + " " + args);
+        Optional<String> patientIndex = options.getValue(PREFIX_OPTION_PATIENT_INDEX);
+        Optional<String> taskIndex = options.getValue(PREFIX_OPTION_TASK_INDEX);
+
+        if (patientIndex.isPresent() && !taskIndex.isPresent()) {
+            return new EditPatientCommandParser().parse(patientIndex.get() + " " + args);
         }
 
-        if (options.getValue(PREFIX_OPTION_PATIENT_INDEX).isPresent()
-                && options.getValue(PREFIX_OPTION_TASK_INDEX).isPresent()) {
-            String patientIndex = options.getValue(PREFIX_OPTION_PATIENT_INDEX).get();
-            String taskIndex = options.getValue(PREFIX_OPTION_TASK_INDEX).get();
-            return new EditTaskCommandParser().parse(patientIndex + " " + taskIndex + " " + args);
+        if (patientIndex.isPresent() && taskIndex.isPresent()) {
+            return new EditTaskCommandParser().parse(patientIndex.get() + " " + taskIndex.get() + " " + args);
         }
 
         throw new ParseException(ParserUtil.MESSAGE_INVALID_OPTIONS);


### PR DESCRIPTION
Resolves #147.

`ParseUtil` now supports parsing `-[option]` command options. We assume that command options never use the character `/`, and they are written before text-based parameters (i.e. `[descriptor]/` parameters).

Additionally, when a user enters a command, two or more consecutive white spaces will be treated as a single white space. E.g., <pre>find  one two   three</pre> will be treated as <pre>find one two three</pre>

Changes the following commands:
- Allow user to call command `add -p PATIENT_INDEX [d/TASK_DESCRIPTION]` to add a task to patient with index `PATIENT_INDEX`. User no longer able to use `addTask` command.
-  `AddPatientCommand` and `AddTaskCommand` now inherits from `AddGenericCommand`. `COMMAND_WORD` is deleted from `AddPatientComand` and `AddTaskCommand`, as they are no longer used.
- Allow user to call command `edit -p PATIENT_INDEX` to edit patient with index `PATIENT_INDEX`. User no longer able to use `editPatient` command.
- Allow user to call command `edit -p PATIENT_INDEX -t TASK_INDEX [d/TASK_DESCRIPTION]` to edit task `TASK_INDEX` of patient with index `PATIENT_INDEX`. User no longer able to use `editTask` command.
-  `EditPatientCommand` and `EditTaskCommand` now inherits from `EditGenericCommand`. `COMMAND_WORD` is deleted from `EditPatientComand` and `EditTaskCommand`, as they are no longer used.
- Allow user to call command `delete -p PATIENT_INDEX` to delete patient with index `PATIENT_INDEX`. User no longer able to use `deletePatient` command.
- Allow user to call command `delete -p PATIENT_INDEX -t TASK_INDEX` to delete task `TASK_INDEX` of patient with index `PATIENT_INDEX`. User no longer able to use `deleteTask` command.
-  `DeletePatientCommand` and `DeleteTaskCommand` now inherits from `DeleteGenericCommand`. `COMMAND_WORD` is deleted from `DeletePatientComand` and `DeleteTaskCommand`, as they are no longer used.

To dos:
- Add documentations.
- Fix message errors