### PR TITLE
Update add method in TaskList to return a new TaskList

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
@@ -53,8 +53,7 @@ public class AddTaskCommand extends Command {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
-        TaskList updatedTaskList = personToEdit.getTasks();
-        updatedTaskList.add(task);
+        TaskList updatedTaskList = personToEdit.getTasks().add(task);
         Person editedPerson = new Person(
                 personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
                 personToEdit.getAddress(), updatedTaskList, personToEdit.getTags());

--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -58,6 +58,7 @@ public class DeleteTaskCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_TASK_INDEX);
         }
 
+        // TODO: update according to new implementation on TaskList#delete
         Task deletedTask = updatedTaskList.delete(taskIndex.getZeroBased());
 
         Person editedPerson = new Person(

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -119,11 +119,10 @@ public class ParserUtil {
     public static TaskList parseTasks(Collection<String> taskDescriptions) throws ParseException {
         requireNonNull(taskDescriptions);
         final ArrayList<Task> tasks = new ArrayList<>();
-        final TaskList taskList = new TaskList(tasks);
         for (String taskDescription : taskDescriptions) {
-            taskList.add(parseTask(taskDescription));
+            tasks.add(parseTask(taskDescription));
         }
-        return taskList;
+        return new TaskList(tasks);
     }
 
     /**

--- a/src/main/java/seedu/address/model/task/TaskList.java
+++ b/src/main/java/seedu/address/model/task/TaskList.java
@@ -13,7 +13,14 @@ public class TaskList {
     private ArrayList<Task> internalTaskList;
 
     /**
-     * Constructs a {@code TaskList}.
+     * Constructs an empty {@code TaskList}.
+     */
+    public TaskList() {
+        internalTaskList = new ArrayList<>();
+    }
+
+    /**
+     * Constructs a {@code TaskList} with a given list of tasks.
      */
     public TaskList(ArrayList<Task> tasks) {
         requireNonNull(tasks);
@@ -21,20 +28,32 @@ public class TaskList {
     }
 
     /**
-     * Adds a task to the list.
+     * Adds a task to the {@code TaskList},
+     * @param task The task to be added.
+     * @return The updated {@code TaskList} containing the added task.
      */
-    public void add(Task task) {
-        requireNonNull(task);
-        internalTaskList.add(task);
+    public TaskList add(Task task) {
+        ArrayList<Task> updatedTasks = new ArrayList<>(internalTaskList);
+        updatedTasks.add(task);
+        return new TaskList(updatedTasks);
     }
 
-    // TODO: add edit method
+    // TODO: add update method
 
+    // TODO: update delete method to return a new TaskList
     /**
      * Removes the task from the list.
      */
     public Task delete(int index) {
         return internalTaskList.remove(index);
+    }
+
+    /**
+     * Returns the task at the specified index.
+     * @return
+     */
+    public Task get(int index) {
+        return internalTaskList.get(index);
     }
 
     /**

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -20,7 +20,7 @@ import seedu.address.model.task.TaskList;
  * Contains utility methods for populating {@code AddressBook} with sample data.
  */
 public class SampleDataUtil {
-    public static final TaskList EMPTY_TASK_LIST = new TaskList(new ArrayList<Task>());
+    public static final TaskList EMPTY_TASK_LIST = new TaskList();
 
     public static Person[] getSamplePersons() {
         return new Person[] {

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -1,6 +1,5 @@
 package seedu.address.testutil;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -38,7 +37,7 @@ public class PersonBuilder {
         phone = new Phone(DEFAULT_PHONE);
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
-        tasks = new TaskList(new ArrayList<>());
+        tasks = new TaskList();
         tags = new HashSet<>();
     }
 


### PR DESCRIPTION
This PR partially makes the `TaskList` immutable by modifying the `TaskList#add` method to return a new `TaskList` that includes the added task, instead of directly modifying it. Note that the `TaskList` constructor that takes in an array list of tasks has been kept public (as opposed to making it private as discussed) because it is also used in the `ParserUtil` class some test-related files.