### PR TITLE
Add tests in `DeleteTaskCommandTest` and `DeleteTaskCommandParserTest`

### DIFF
--- a/src/main/java/seedu/address/logic/parser/DeleteTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteTaskCommandParser.java
@@ -14,8 +14,6 @@ import seedu.address.logic.parser.exceptions.ParseException;
  */
 public class DeleteTaskCommandParser implements Parser<DeleteTaskCommand> {
 
-    public static final String MESSAGE_INVALID_NUMBER_OF_INDICES = "Invalid number of indices";
-
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteTaskCommand
      * and returns a DeleteTaskCommand object for execution.

--- a/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
@@ -1,13 +1,145 @@
 package seedu.address.logic.commands;
 
-//import static org.junit.jupiter.api.Assertions.assertFalse;
-//import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_TASK;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Patient;
+import seedu.address.model.task.Task;
+import seedu.address.testutil.PersonBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for {@code DeleteTaskCommand}.
+ */
 class DeleteTaskCommandTest {
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
-    void execute() {
+    public void constructor_nullTaskIndex_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new DeleteTaskCommand(INDEX_SECOND_PERSON, null));
+    }
+
+    @Test
+    public void constructor_nullPatientIndex_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new DeleteTaskCommand(null, INDEX_FIRST_TASK));
+    }
+
+    @Test
+    public void execute_nullModel_throwsNullPointerException() {
+        DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(INDEX_SECOND_PERSON, INDEX_FIRST_TASK);
+        assertThrows(NullPointerException.class, () -> deleteTaskCommand.execute(null));
+    }
+
+    @Test
+    void execute_validIndicesUnfilteredList_success() {
+        // use third person in TypicalPersons since there is one task to delete
+        Patient patientToDeleteTask = model.getFilteredPersonList().get(INDEX_THIRD_PERSON.getZeroBased());
+        Patient editedPatient = new PersonBuilder(patientToDeleteTask).withTasks().build();
+        Task deletedTask = patientToDeleteTask.getTasks().get(INDEX_FIRST_TASK.getZeroBased());
+
+        DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(INDEX_THIRD_PERSON, INDEX_FIRST_TASK);
+
+        String expectedMessage = String.format(DeleteTaskCommand.MESSAGE_DELETE_TASK_SUCCESS,
+                editedPatient.getName().toString(), deletedTask);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(patientToDeleteTask, editedPatient);
+
+        assertCommandSuccess(deleteTaskCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    void execute_invalidPatientIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundPatientIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(outOfBoundPatientIndex, INDEX_FIRST_TASK);
+
+        assertCommandFailure(deleteTaskCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    void execute_validIndicesFilteredList_success() {
+        // use third person in TypicalPersons since there is one task to delete
+        showPersonAtIndex(model, INDEX_THIRD_PERSON);
+
+        Patient patientToDeleteTask = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Patient editedPatient = new PersonBuilder(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()))
+                .withTasks().build();
+        Task deletedTask = patientToDeleteTask.getTasks().get(INDEX_FIRST_TASK.getZeroBased());
+
+        DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(INDEX_FIRST_PERSON, INDEX_FIRST_TASK);
+
+        String expectedMessage = String.format(DeleteTaskCommand.MESSAGE_DELETE_TASK_SUCCESS,
+                editedPatient.getName().toString(), deletedTask);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(patientToDeleteTask, editedPatient);
+
+        assertCommandSuccess(deleteTaskCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    void execute_invalidPatientIndexFilteredList_throwsCommandException() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(outOfBoundIndex, INDEX_FIRST_TASK);
+
+        assertCommandFailure(deleteTaskCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    void execute_invalidTaskIndex_throwsCommandException() {
+        Patient patient = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Index outOfBoundTaskIndex = Index.fromOneBased(patient.getTasks().size() + 1);
+        DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(INDEX_FIRST_PERSON, outOfBoundTaskIndex);
+
+        assertCommandFailure(deleteTaskCommand, model, Messages.MESSAGE_INVALID_TASK_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        DeleteTaskCommand deleteTaskFirstCommand = new DeleteTaskCommand(INDEX_FIRST_PERSON, INDEX_FIRST_TASK);
+        DeleteTaskCommand deleteTaskSecondCommand = new DeleteTaskCommand(INDEX_SECOND_PERSON, INDEX_FIRST_TASK);
+        DeleteTaskCommand deleteTaskThirdCommand = new DeleteTaskCommand(INDEX_FIRST_PERSON, INDEX_SECOND_TASK);
+
+        // same object -> returns true
+        assertEquals(deleteTaskFirstCommand, deleteTaskFirstCommand);
+
+        // same values -> returns true
+        DeleteTaskCommand deleteTaskFirstCommandCopy = new DeleteTaskCommand(INDEX_FIRST_PERSON, INDEX_FIRST_TASK);
+        assertEquals(deleteTaskFirstCommand, deleteTaskFirstCommandCopy);
+
+        // different types -> returns false
+        assertNotEquals(1, deleteTaskFirstCommand);
+
+        // null -> returns false
+        assertNotEquals(null, deleteTaskFirstCommand);
+
+        // different person index -> returns false
+        assertNotEquals(deleteTaskFirstCommand, deleteTaskSecondCommand);
+
+        // different task index -> returns false
+        assertNotEquals(deleteTaskFirstCommand, deleteTaskThirdCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/EditTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditTaskCommandTest.java
@@ -6,10 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalTasks.TASK_CARE_PLAN;
 
 import org.junit.jupiter.api.Test;
 
@@ -24,13 +26,37 @@ import seedu.address.model.task.Task;
 import seedu.address.testutil.PersonBuilder;
 
 /**
- * Contains integration tests (interaction with the Model) and unit tests for EditTaskCommand.
+ * Contains integration tests (interaction with the Model) and unit tests for {@code EditTaskCommand}.
  */
 class EditTaskCommandTest {
 
     private static final String TASK_STUB = "Some task";
 
     private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void constructor_nullPatientIndex_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new EditTaskCommand(null, INDEX_FIRST_TASK, TASK_CARE_PLAN));
+    }
+
+    @Test
+    public void constructor_nullTaskIndex_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new EditTaskCommand(INDEX_FIRST_PERSON, null, TASK_CARE_PLAN));
+    }
+
+    @Test
+    public void constructor_nullTask_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new EditTaskCommand(INDEX_FIRST_PERSON, INDEX_FIRST_TASK, null));
+    }
+
+    @Test
+    public void execute_nullModel_throwsNullPointerException() {
+        EditTaskCommand editTaskCommand = new EditTaskCommand(INDEX_FIRST_PERSON, INDEX_FIRST_TASK, TASK_CARE_PLAN);
+        assertThrows(NullPointerException.class, () -> editTaskCommand.execute(null));
+    }
 
     @Test
     public void execute_editTask_success() {

--- a/src/test/java/seedu/address/logic/parser/DeleteTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteTaskCommandParserTest.java
@@ -1,13 +1,47 @@
 package seedu.address.logic.parser;
 
-//import static org.junit.jupiter.api.Assertions.assertFalse;
-//import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.DeleteTaskCommand;
+
+/**
+ * Contains unit tests for {@code DeleteTaskCommandParser}.
+ */
 class DeleteTaskCommandParserTest {
 
+    private final DeleteTaskCommandParser parser = new DeleteTaskCommandParser();
+
     @Test
-    void parse() {
+    public void parse_nullArgs_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> parser.parse(null));
+    }
+
+    @Test
+    public void parse_validArgs_returnsDeleteTaskCommand() {
+        assertParseSuccess(parser, "1 1", new DeleteTaskCommand(INDEX_FIRST_PERSON, INDEX_FIRST_TASK));
+        assertParseSuccess(parser, " 1 1 ", new DeleteTaskCommand(INDEX_FIRST_PERSON, INDEX_FIRST_TASK));
+    }
+
+    @Test
+    public void parse_invalidPatientIndex_throwsParserException() {
+        assertParseFailure(parser, "a 1",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTaskCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "0 1",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTaskCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidTaskIndex_throwsParserException() {
+        assertParseFailure(parser, "1 a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTaskCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "1 0",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTaskCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditTaskCommandParserTest.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK_DESCRIPTION;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TASK;
 
@@ -13,12 +14,17 @@ import seedu.address.logic.commands.EditTaskCommand;
 import seedu.address.model.task.Task;
 
 /**
- * Contains unit tests for EditTaskCommandParser.
+ * Contains unit tests for {@code EditTaskCommandParser).
  */
 class EditTaskCommandParserTest {
 
     private final EditTaskCommandParser parser = new EditTaskCommandParser();
     private final String nonEmptyTask = "Some task";
+
+    @Test
+    public void parse_nullArgs_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> parser.parse(null));
+    }
 
     @Test
     public void parse_patientIndexSpecifiedTaskIndexSpecified_success() {

--- a/src/test/java/seedu/address/logic/parser/EditTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditTaskCommandParserTest.java
@@ -14,7 +14,7 @@ import seedu.address.logic.commands.EditTaskCommand;
 import seedu.address.model.task.Task;
 
 /**
- * Contains unit tests for {@code EditTaskCommandParser).
+ * Contains unit tests for {@code EditTaskCommandParser}.
  */
 class EditTaskCommandParserTest {
 


### PR DESCRIPTION
This PR adds integration and unit tests to the `DeleteTaskCommandTest` class and unit tests to `DeleteTaskCommandParserTest` class. Some tests for `null` parameters in `EditTaskCommandTest` and `EditTaskCommandParserTest` are added too, for code coverage.