### PR TITLE
Feature add base medical condition classes

### DIFF
--- a/src/main/java/seedu/uninurse/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/uninurse/logic/parser/CliSyntax.java
@@ -12,6 +12,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TASK_DESCRIPTION = new Prefix("d/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_CONDITION = new Prefix("c/");
     public static final Prefix PREFIX_OPTION_PATIENT_INDEX = new Prefix("-p");
     public static final Prefix PREFIX_OPTION_TASK_INDEX = new Prefix("-t");
+    public static final Prefix PREFIX_OPTION_CONDITION_INDEX = new Prefix("-c");
 }

--- a/src/main/java/seedu/uninurse/model/condition/Condition.java
+++ b/src/main/java/seedu/uninurse/model/condition/Condition.java
@@ -1,0 +1,2 @@
+package seedu.uninurse.model.condition;public class Condition {
+}

--- a/src/main/java/seedu/uninurse/model/condition/Condition.java
+++ b/src/main/java/seedu/uninurse/model/condition/Condition.java
@@ -1,2 +1,56 @@
-package seedu.uninurse.model.condition;public class Condition {
+package seedu.uninurse.model.condition;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.uninurse.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Patient's medical condition.
+ * Guarantees: immutable; is valid as declared in {@link #isValidCondition(String)}
+ */
+public class Condition {
+
+    public static final String MESSAGE_CONSTRAINTS = "Conditions can take any values, and it should not be blank";
+
+    /*
+     * The first character of the condition must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[^\\s].*";
+
+    public final String condition;
+
+    /**
+     * Constructs a {@code Condition}.
+     *
+     * @param condition A valid condition.
+     */
+    public Condition(String condition) {
+        requireNonNull(condition);
+        checkArgument(isValidCondition(condition), MESSAGE_CONSTRAINTS);
+        this.condition = condition;
+    }
+
+    /**
+     * Returns true if a given string is a valid condition.
+     */
+    public static boolean isValidCondition(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return condition;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Condition // instanceof handles nulls
+                && condition.equals(((Condition) other).condition)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return condition.hashCode();
+    }
 }

--- a/src/main/java/seedu/uninurse/model/condition/ConditionList.java
+++ b/src/main/java/seedu/uninurse/model/condition/ConditionList.java
@@ -26,13 +26,19 @@ public class ConditionList implements GenericList<Condition> {
     }
 
     /**
-     * Constructs a {@code ConditionList} with a given list of conditions.
+     * Constructs a {@code ConditionList}.
+     * @param conditions The given list of conditions.
      */
     public ConditionList(ArrayList<Condition> conditions) {
         requireNonNull(conditions);
         internalConditionList = conditions;
     }
 
+    /**
+     * Checks if the list already contains a given condition.
+     * @param toCheck The condition to be checked.
+     * @return Returns true if the list contains an equivalent condition as the given argument.
+     */
     public boolean contains(Condition toCheck) {
         requireNonNull(toCheck);
         return internalConditionList.stream().anyMatch(toCheck::equals);

--- a/src/main/java/seedu/uninurse/model/condition/ConditionList.java
+++ b/src/main/java/seedu/uninurse/model/condition/ConditionList.java
@@ -1,0 +1,2 @@
+package seedu.uninurse.model.condition;public class ConditionList {
+}

--- a/src/main/java/seedu/uninurse/model/condition/ConditionList.java
+++ b/src/main/java/seedu/uninurse/model/condition/ConditionList.java
@@ -1,2 +1,85 @@
-package seedu.uninurse.model.condition;public class ConditionList {
+package seedu.uninurse.model.condition;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import seedu.uninurse.model.GenericList;
+import seedu.uninurse.model.condition.exceptions.DuplicateConditionException;
+
+/**
+ * Represents a unique list of medical conditions for a particular patient.
+ * Two conditions with the same name are considered duplicates and are hence, not allowed.
+ * Supports a minimal set of list operations.
+ */
+public class ConditionList implements GenericList<Condition> {
+    public static final String MESSAGE_UNSUPPORTED_EDIT = "Conditions cannot be edited, only added or deleted";
+
+    private ArrayList<Condition> internalConditionList;
+
+    /**
+     * Constructs an empty {@code ConditionList}.
+     */
+    public ConditionList() {
+        internalConditionList = new ArrayList<>();
+    }
+
+    /**
+     * Constructs a {@code ConditionList} with a given list of conditions.
+     */
+    public ConditionList(ArrayList<Condition> conditions) {
+        requireNonNull(conditions);
+        internalConditionList = conditions;
+    }
+
+    public boolean contains(Condition toCheck) {
+        requireNonNull(toCheck);
+        return internalConditionList.stream().anyMatch(toCheck::equals);
+    }
+
+    @Override
+    public ConditionList add(Condition condition) {
+        requireNonNull(condition);
+        if (contains(condition)) {
+            throw new DuplicateConditionException();
+        }
+
+        ArrayList<Condition> updatedConditions = new ArrayList<>(internalConditionList);
+        updatedConditions.add(condition);
+        return new ConditionList(updatedConditions);
+    }
+
+    @Override
+    public ConditionList delete(int index) {
+        ArrayList<Condition> updatedConditions = new ArrayList<>(internalConditionList);
+        updatedConditions.remove(index);
+        return new ConditionList(updatedConditions);
+    }
+
+    @Override
+    public ConditionList edit(int index, Condition condition) {
+        throw new UnsupportedOperationException(MESSAGE_UNSUPPORTED_EDIT);
+    }
+
+    @Override
+    public Condition get(int index) {
+        return internalConditionList.get(index);
+    }
+
+    @Override
+    public int size() {
+        return internalConditionList.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return internalConditionList.isEmpty();
+    }
+
+    @Override
+    public ArrayList<Condition> getInternalList() {
+        // returns a copy of the internal list to prevent modification to original one
+        return new ArrayList<>(internalConditionList);
+    }
 }

--- a/src/main/java/seedu/uninurse/model/condition/ConditionList.java
+++ b/src/main/java/seedu/uninurse/model/condition/ConditionList.java
@@ -3,9 +3,9 @@ package seedu.uninurse.model.condition;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import seedu.uninurse.model.GenericList;
+import seedu.uninurse.model.condition.exceptions.ConditionNotFoundException;
 import seedu.uninurse.model.condition.exceptions.DuplicateConditionException;
 
 /**
@@ -52,9 +52,13 @@ public class ConditionList implements GenericList<Condition> {
 
     @Override
     public ConditionList delete(int index) {
-        ArrayList<Condition> updatedConditions = new ArrayList<>(internalConditionList);
-        updatedConditions.remove(index);
-        return new ConditionList(updatedConditions);
+        try {
+            ArrayList<Condition> updatedConditions = new ArrayList<>(internalConditionList);
+            updatedConditions.remove(index);
+            return new ConditionList(updatedConditions);
+        } catch (IndexOutOfBoundsException e) {
+            throw new ConditionNotFoundException();
+        }
     }
 
     @Override
@@ -64,7 +68,11 @@ public class ConditionList implements GenericList<Condition> {
 
     @Override
     public Condition get(int index) {
-        return internalConditionList.get(index);
+        try {
+            return internalConditionList.get(index);
+        } catch (IndexOutOfBoundsException e) {
+            throw new ConditionNotFoundException();
+        }
     }
 
     @Override

--- a/src/main/java/seedu/uninurse/model/condition/exceptions/ConditionNotFoundException.java
+++ b/src/main/java/seedu/uninurse/model/condition/exceptions/ConditionNotFoundException.java
@@ -1,0 +1,7 @@
+package seedu.uninurse.model.condition.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified condition.
+ */
+public class ConditionNotFoundException extends RuntimeException {
+}

--- a/src/main/java/seedu/uninurse/model/condition/exceptions/DuplicateConditionException.java
+++ b/src/main/java/seedu/uninurse/model/condition/exceptions/DuplicateConditionException.java
@@ -1,2 +1,11 @@
-package seedu.uninurse.model.condition.exceptions;public class DuplicateConditionException {
+package seedu.uninurse.model.condition.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Conditions.
+ * Conditions are considered duplicates if they have the same name.
+ */
+public class DuplicateConditionException extends RuntimeException {
+    public DuplicateConditionException() {
+        super("Operation would result in duplicate conditions");
+    }
 }

--- a/src/main/java/seedu/uninurse/model/condition/exceptions/DuplicateConditionException.java
+++ b/src/main/java/seedu/uninurse/model/condition/exceptions/DuplicateConditionException.java
@@ -1,0 +1,2 @@
+package seedu.uninurse.model.condition.exceptions;public class DuplicateConditionException {
+}

--- a/src/main/java/seedu/uninurse/model/task/Task.java
+++ b/src/main/java/seedu/uninurse/model/task/Task.java
@@ -5,7 +5,7 @@ import static seedu.uninurse.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents a Task for a Patient.
- * Guarantees: immutable; is always valid
+ * Guarantees: immutable; is valid as declared in {@link #isValidTaskDescription(String)}
  */
 public class Task {
     // consideration for v1.3: display status of task, which is to be

--- a/src/test/java/seedu/uninurse/model/condition/ConditionTest.java
+++ b/src/test/java/seedu/uninurse/model/condition/ConditionTest.java
@@ -1,0 +1,78 @@
+package seedu.uninurse.model.condition;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.uninurse.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class ConditionTest {
+    // may be moved to a utility class if sample conditions are needed in other tests
+    private final Condition diabetesCondition = new Condition("Type II Diabetes");
+    private final Condition osteoporosisCondition = new Condition("Osteoporosis");
+    private final String diabetesConditionName = "Type II Diabetes";
+
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Condition(null));
+    }
+
+    @Test
+    public void constructor_invalidCondition_throwsIllegalArgumentException() {
+        String invalidCondition = "";
+        assertThrows(IllegalArgumentException.class, () -> new Condition(invalidCondition));
+    }
+
+    @Test
+    public void isValidCondition_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> Condition.isValidCondition(null));
+    }
+
+    @Test
+    public void isValidCondition_validCondition_returnsTrue() {
+        // numbers in task description -> returns true
+        assertTrue(Condition.isValidCondition("123"));
+
+        // special characters in task description -> returns true
+        assertTrue(Condition.isValidCondition("@!#$%^&*()-=+_[];.,`~:<>?/"));
+
+        // valid task description -> returns true
+        assertTrue(Condition.isValidCondition("Check vitals"));
+    }
+
+    @Test
+    public void isValidCondition_invalidCondition_returnsFalse() {
+        // empty task description -> returns false
+        assertFalse(Condition.isValidCondition(""));
+
+        // blank task description -> returns false
+        assertFalse(Condition.isValidCondition("  "));
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals(diabetesCondition.toString(), diabetesConditionName);
+    }
+
+    @Test
+    public void equals() {
+        // same object -> returns true
+        assertEquals(diabetesCondition, diabetesCondition);
+
+        // same values -> returns true
+        Condition diabetesConditionCopy = new Condition(diabetesConditionName);
+        assertEquals(diabetesCondition, diabetesConditionCopy);
+
+        // different types -> returns false
+        assertNotEquals(1, diabetesCondition);
+
+        // null -> returns false
+        assertNotEquals(null, diabetesCondition);
+
+        // different description -> returns false
+        assertNotEquals(diabetesCondition, osteoporosisCondition);
+    }
+}


### PR DESCRIPTION
Closes #179 

This PR adds a `Condition` class and  a `ConditionList` class that will later be used to implement a working command to add a medical condition to a `Patient`. Other additions are described as follows:
- Add unit tests for the `Condition` class.
- Add custom exception classes to handle condition-related errors.
- Duplicate conditions (conditions with the same name) are disallowed in `ConditionList`
- A `Condition` can only be **added** or **deleted** to a `Patient`, **never edited**. Since conditions are usually short, editing them is redundant. Hence the `ConditionList#edit` method throws an exception when invoked.
