### PR TITLE
Add selective clear feature

### DIFF
--- a/src/main/java/seedu/uninurse/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/ClearCommand.java
@@ -2,8 +2,11 @@ package seedu.uninurse.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import seedu.uninurse.model.Model;
-import seedu.uninurse.model.UninurseBook;
+import seedu.uninurse.model.person.Patient;
 
 /**
  * Clears the uninurse book.
@@ -17,7 +20,10 @@ public class ClearCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.setUninurseBook(new UninurseBook());
+        List<Patient> lastShownList = new ArrayList<Patient>(model.getFilteredPersonList());
+        for (Patient patientToDelete : lastShownList) {
+            model.deletePerson(patientToDelete);
+        }
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }


### PR DESCRIPTION
Modify command `clear` to the following:
- Deletes all `Patient`s in the *currently displayed* list. E.g., `find john` followed by `clear` will delete all `Patient`s with `john` in their name.