### PR TITLE
Add navigate command history feature

### DIFF
--- a/src/main/java/seedu/uninurse/commons/core/Config.java
+++ b/src/main/java/seedu/uninurse/commons/core/Config.java
@@ -12,6 +12,9 @@ public class Config {
 
     public static final Path DEFAULT_CONFIG_FILE = Paths.get("config.json");
 
+    public static final int HISTORY_SIZE_LIMIT = 100;
+
+
     // Config values customizable through config file
     private Level logLevel = Level.INFO;
     private Path userPrefsFilePath = Paths.get("preferences.json");

--- a/src/main/java/seedu/uninurse/ui/CommandBox.java
+++ b/src/main/java/seedu/uninurse/ui/CommandBox.java
@@ -2,12 +2,14 @@ package seedu.uninurse.ui;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
+import seedu.uninurse.commons.core.Config;
 import seedu.uninurse.logic.commands.CommandResult;
 import seedu.uninurse.logic.commands.exceptions.CommandException;
 import seedu.uninurse.logic.parser.exceptions.ParseException;
@@ -60,21 +62,21 @@ public class CommandBox extends UiPart<Region> {
      */
     @FXML
     private void handleOnKeyPressed(KeyEvent keyEvent) {
-        System.out.println(keyEvent.getCode());
+        Optional<String> text;
         switch (keyEvent.getCode()) {
         case UP:
-            if (history.handleUpKey()) {
-                commandTextField.setText(history.get());
-            }
+            text = history.handleUpKey();
             break;
         case DOWN:
-            if (history.handleDownKey()) {
-                commandTextField.setText(history.get());
-            }
+            text = history.handleDownKey();
             break;
         default:
-            // Default onKeyPress event
+            text = Optional.empty();
             break;
+        }
+        if (text.isPresent()) {
+            commandTextField.setText(text.get());
+            commandTextField.positionCaret(text.get().length());
         }
     }
 
@@ -115,7 +117,6 @@ public class CommandBox extends UiPart<Region> {
      * The command history list.
      */
     private static final class CommandHistoryList {
-        private final int sizeLimit = 100;
         private final List<String> history;
         private int currentPointer;
 
@@ -123,9 +124,9 @@ public class CommandBox extends UiPart<Region> {
          * Creates a {@code CommandHistoryList}.
          */
         public CommandHistoryList() {
-            history = new ArrayList<String>();
-            history.add("");
-            currentPointer = 0;
+            this.history = new ArrayList<String>();
+            this.history.add("");
+            this.currentPointer = 0;
         }
 
         /**
@@ -135,7 +136,7 @@ public class CommandBox extends UiPart<Region> {
             if (history.size() < 2 || !history.get(history.size() - 2).equals(command)) {
                 // Update history only if the new command is different from the last one
                 history.set(history.size() - 1, command);
-                while (history.size() > sizeLimit) {
+                while (history.size() > Config.HISTORY_SIZE_LIMIT) {
                     history.remove(0);
                 }
                 history.add("");
@@ -146,29 +147,29 @@ public class CommandBox extends UiPart<Region> {
         /**
          * Handles the Up Key Button Pressed event.
          */
-        public boolean handleUpKey() {
+        public Optional<String> handleUpKey() {
             if (currentPointer == 0) {
-                return false;
+                return Optional.empty();
             }
             currentPointer -= 1;
-            return true;
+            return Optional.of(this.get());
         }
 
         /**
          * Handles the Down Key Button Pressed event.
          */
-        public boolean handleDownKey() {
+        public Optional<String> handleDownKey() {
             if (currentPointer + 1 == history.size()) {
-                return false;
+                return Optional.empty();
             }
             currentPointer += 1;
-            return true;
+            return Optional.of(this.get());
         }
 
         /**
          * Returns the command currently pointed to in the history list.
          */
-        public String get() {
+        private String get() {
             return history.get(currentPointer);
         }
     }

--- a/src/main/java/seedu/uninurse/ui/CommandBox.java
+++ b/src/main/java/seedu/uninurse/ui/CommandBox.java
@@ -142,12 +142,14 @@ public class CommandBox extends UiPart<Region> {
                 history.add("");
             }
             currentPointer = history.size() - 1;
+            assert 1 <= history.size() && history.size() <= Config.HISTORY_SIZE_LIMIT + 1;
         }
 
         /**
          * Handles the Up Key Button Pressed event.
          */
         public Optional<String> handleUpKey() {
+            assert 0 <= currentPointer && currentPointer <= history.size() - 1;
             if (currentPointer == 0) {
                 return Optional.empty();
             }
@@ -159,6 +161,7 @@ public class CommandBox extends UiPart<Region> {
          * Handles the Down Key Button Pressed event.
          */
         public Optional<String> handleDownKey() {
+            assert 0 <= currentPointer && currentPointer <= history.size() - 1;
             if (currentPointer + 1 == history.size()) {
                 return Optional.empty();
             }
@@ -170,6 +173,7 @@ public class CommandBox extends UiPart<Region> {
          * Returns the command currently pointed to in the history list.
          */
         private String get() {
+            assert 0 <= currentPointer && currentPointer <= history.size() - 1;
             return history.get(currentPointer);
         }
     }

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -4,6 +4,6 @@
 <?import javafx.scene.layout.StackPane?>
 
 <StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here..."/>
+  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" onKeyPressed="#handleOnKeyPressed" promptText="Enter command here..."/>
 </StackPane>
 


### PR DESCRIPTION
Resolves #134.

The command history works as follows:
- Press the `Up` key to navigate to the previous command, and the `Down` key to the next command  in the history list. The cursor will be set to the end of the text. Note that if we are currently at the beginning of the history, pressing `Up` will move the cursor to the beginning of the text and not change the current text (i.e. default behavior); if we are currently at the end of the history, pressing `Down` will move the cursor to the end of the text and not change the current text (i.e. default behavior); 
- If we entered a successful command which is different from the last successful command, then the new command will be pushed into the history list. If it is the same as the last successful command, then the new command will not be pushed into the history list.
- The history list has maximum size 100. Beyond that, it will delete the least recent command history.