### PR TITLE
Fix command type standardization

### DIFF
--- a/src/main/java/seedu/uninurse/logic/commands/AddConditionCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/AddConditionCommand.java
@@ -30,6 +30,8 @@ public class AddConditionCommand extends AddGenericCommand {
 
     public static final String MESSAGE_ADD_CONDITION_SUCCESS = "New condition added to %1$s: %2$s";
 
+    public static final CommandType ADD_CONDITION_COMMAND_TYPE = CommandType.EDIT_PATIENT;
+
     private final Index index;
     private final Condition condition;
 
@@ -63,7 +65,8 @@ public class AddConditionCommand extends AddGenericCommand {
         model.setPerson(patientToEdit, editedPatient);
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
 
-        return new CommandResult(String.format(MESSAGE_ADD_CONDITION_SUCCESS, editedPatient.getName(), condition));
+        return new CommandResult(String.format(MESSAGE_ADD_CONDITION_SUCCESS, editedPatient.getName(), condition),
+                ADD_CONDITION_COMMAND_TYPE);
     }
 
     @Override

--- a/src/main/java/seedu/uninurse/logic/commands/AddPatientCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/AddPatientCommand.java
@@ -39,6 +39,8 @@ public class AddPatientCommand extends AddGenericCommand {
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the uninurse book";
 
+    public static final CommandType ADD_PATIENT_COMMAND_TYPE = CommandType.ADD_PATIENT;
+
     private final Patient toAdd;
 
     /**
@@ -59,7 +61,7 @@ public class AddPatientCommand extends AddGenericCommand {
 
         model.addPerson(toAdd);
         model.setPatientOfInterest(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), CommandType.ADD_PATIENT);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), ADD_PATIENT_COMMAND_TYPE);
     }
 
     @Override

--- a/src/main/java/seedu/uninurse/logic/commands/AddTaskCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/AddTaskCommand.java
@@ -28,6 +28,8 @@ public class AddTaskCommand extends AddGenericCommand {
 
     public static final String MESSAGE_ADD_TASK_SUCCESS = "New task added to %1$s: %2$s";
 
+    public static final CommandType ADD_TASK_COMMAND_TYPE = CommandType.TASK;
+
     private final Index index;
     private final Task task;
 
@@ -63,7 +65,7 @@ public class AddTaskCommand extends AddGenericCommand {
         model.setPatientOfInterest(editedPerson);
 
         return new CommandResult(String.format(MESSAGE_ADD_TASK_SUCCESS, editedPerson.getName().toString(), task),
-                CommandType.TASK);
+                ADD_TASK_COMMAND_TYPE);
     }
 
     @Override

--- a/src/main/java/seedu/uninurse/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/ClearCommand.java
@@ -12,10 +12,10 @@ import seedu.uninurse.model.person.Patient;
  * Clears the uninurse book.
  */
 public class ClearCommand extends UndoableCommand {
-
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "Listed patients have been cleared!";
 
+    public static final CommandType CLEAR_COMMAND_TYPE = CommandType.CLEAR;
 
     @Override
     public CommandResult execute(Model model) {
@@ -24,6 +24,6 @@ public class ClearCommand extends UndoableCommand {
         for (Patient patientToDelete : lastShownList) {
             model.deletePerson(patientToDelete);
         }
-        return new CommandResult(MESSAGE_SUCCESS, CommandType.CLEAR);
+        return new CommandResult(MESSAGE_SUCCESS, CLEAR_COMMAND_TYPE);
     }
 }

--- a/src/main/java/seedu/uninurse/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/uninurse/logic/commands/CommandResult.java
@@ -8,18 +8,9 @@ import java.util.Objects;
  * Represents the result of a command execution.
  */
 public class CommandResult {
-
     private final String feedbackToUser;
 
-
-    ///** Help information should be shown to the user. */
-    //private final boolean showHelp;
-
-    ///** The application should exit. */
-    //private final boolean exit;
-
     private final CommandType commandType;
-
 
     /**
      * Constructs a {@code CommandResult} with the specified fields.
@@ -43,10 +34,6 @@ public class CommandResult {
         return this.commandType == CommandType.EXIT;
     }
 
-    public boolean isTaskRelated() {
-        return this.commandType == CommandType.TASK;
-    }
-
     public boolean isAddPatient() {
         return this.commandType == CommandType.ADD_PATIENT;
     }
@@ -59,10 +46,13 @@ public class CommandResult {
         return this.commandType == CommandType.DELETE_PATIENT;
     }
 
+    public boolean isTaskRelated() {
+        return this.commandType == CommandType.TASK;
+    }
+
     public boolean isSchedule() {
         return this.commandType == CommandType.SCHEDULE;
     }
-
 
     @Override
     public boolean equals(Object other) {
@@ -78,12 +68,10 @@ public class CommandResult {
         CommandResult otherCommandResult = (CommandResult) other;
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
                 && this.commandType == otherCommandResult.commandType;
-
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(feedbackToUser, commandType);
     }
-
 }

--- a/src/main/java/seedu/uninurse/logic/commands/CommandType.java
+++ b/src/main/java/seedu/uninurse/logic/commands/CommandType.java
@@ -4,5 +4,18 @@ package seedu.uninurse.logic.commands;
  * CommandType is an enum which contains the different types of commands in UniNurse.
  */
 public enum CommandType {
-    TEST, EMPTY, HELP, EXIT, TASK, ADD_PATIENT, EDIT_PATIENT, DELETE_PATIENT, CLEAR, LIST, SCHEDULE, FIND, UNDO, REDO;
+    TEST,
+    EMPTY,
+    HELP,
+    EXIT,
+    ADD_PATIENT,
+    EDIT_PATIENT,
+    DELETE_PATIENT,
+    LIST,
+    TASK,
+    SCHEDULE,
+    FIND,
+    CLEAR,
+    UNDO,
+    REDO;
 }

--- a/src/main/java/seedu/uninurse/logic/commands/DeletePatientCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/DeletePatientCommand.java
@@ -21,13 +21,14 @@ public class DeletePatientCommand extends DeleteGenericCommand {
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Patient: %1$s";
 
+    public static final CommandType DELETE_PATIENT_COMMAND_TYPE = CommandType.DELETE_PATIENT;
+
     private final Index targetIndex;
 
     public DeletePatientCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
     }
 
-    // TODO - Update model and patient once they are done
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
@@ -41,7 +42,7 @@ public class DeletePatientCommand extends DeleteGenericCommand {
         model.deletePerson(patientToDelete);
         model.setPatientOfInterest(patientToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, patientToDelete),
-                CommandType.DELETE_PATIENT);
+                DELETE_PATIENT_COMMAND_TYPE);
     }
 
     @Override

--- a/src/main/java/seedu/uninurse/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/DeleteTaskCommand.java
@@ -26,6 +26,8 @@ public class DeleteTaskCommand extends DeleteGenericCommand {
 
     public static final String MESSAGE_DELETE_TASK_SUCCESS = "Deleted task from %1$s: %2$s";
 
+    public static final CommandType DELETE_TASK_COMMAND_TYPE = CommandType.TASK;
+
     private final Index patientIndex;
     private final Index taskIndex;
 
@@ -70,7 +72,7 @@ public class DeleteTaskCommand extends DeleteGenericCommand {
         model.setPatientOfInterest(editedPerson);
 
         return new CommandResult(String.format(MESSAGE_DELETE_TASK_SUCCESS, editedPerson.getName(), deletedTask),
-                CommandType.TASK);
+                DELETE_TASK_COMMAND_TYPE);
     }
 
     @Override

--- a/src/main/java/seedu/uninurse/logic/commands/EditPatientCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/EditPatientCommand.java
@@ -49,6 +49,8 @@ public class EditPatientCommand extends EditGenericCommand {
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PATIENT = "This patient already exists in the uninurse book.";
 
+    public static final CommandType EDIT_PATIENT_COMMAND_TYPE = CommandType.EDIT_PATIENT;
+
     private final Index index;
     private final EditPatientDescriptor editPatientDescriptor;
 
@@ -84,7 +86,7 @@ public class EditPatientCommand extends EditGenericCommand {
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         model.setPatientOfInterest(editedPatient);
         return new CommandResult(String.format(MESSAGE_EDIT_PATIENT_SUCCESS, editedPatient),
-                CommandType.EDIT_PATIENT);
+                EDIT_PATIENT_COMMAND_TYPE);
     }
 
     /**

--- a/src/main/java/seedu/uninurse/logic/commands/EditTaskCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/EditTaskCommand.java
@@ -35,6 +35,8 @@ public class EditTaskCommand extends EditGenericCommand {
     public static final String MESSAGE_EDIT_TASK_SUCCESS = "Edited Task: %1$s";
     public static final String MESSAGE_NOT_EDITED = "Task to edit must be provided.";
 
+    public static final CommandType EDIT_TASK_COMMAND_TYPE = CommandType.TASK;
+
     private final Index patientIndex;
     private final Index taskIndex;
     private final Task updatedTask;
@@ -75,7 +77,7 @@ public class EditTaskCommand extends EditGenericCommand {
         model.updateFilteredPersonList(patient -> patient.equals(editedPatient));
         model.setPatientOfInterest(editedPatient);
         return new CommandResult(String.format(MESSAGE_EDIT_TASK_SUCCESS, editedPatient),
-                CommandType.TASK);
+                EDIT_TASK_COMMAND_TYPE);
     }
 
     /**

--- a/src/main/java/seedu/uninurse/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/ExitCommand.java
@@ -6,14 +6,14 @@ import seedu.uninurse.model.Model;
  * Terminates the program.
  */
 public class ExitCommand extends Command {
-
     public static final String COMMAND_WORD = "exit";
 
     public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting UniNurse Book as requested ...";
 
+    public static final CommandType EXIT_COMMAND_TYPE = CommandType.EXIT;
+
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, CommandType.EXIT);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, EXIT_COMMAND_TYPE);
     }
-
 }

--- a/src/main/java/seedu/uninurse/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/FindCommand.java
@@ -11,13 +11,14 @@ import seedu.uninurse.model.person.NameContainsKeywordsPredicate;
  * Keyword matching is case insensitive.
  */
 public class FindCommand extends Command {
-
     public static final String COMMAND_WORD = "find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all patients whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
+
+    public static final CommandType FIND_COMMAND_TYPE = CommandType.FIND;
 
     private final NameContainsKeywordsPredicate predicate;
 
@@ -31,7 +32,7 @@ public class FindCommand extends Command {
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()),
-                CommandType.FIND);
+                FIND_COMMAND_TYPE);
     }
 
     @Override

--- a/src/main/java/seedu/uninurse/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/HelpCommand.java
@@ -6,7 +6,6 @@ import seedu.uninurse.model.Model;
  * Format full help instructions for every command for display.
  */
 public class HelpCommand extends Command {
-
     public static final String COMMAND_WORD = "help";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
@@ -14,8 +13,10 @@ public class HelpCommand extends Command {
 
     public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
 
+    public static final CommandType HELP_COMMAND_TYPE = CommandType.HELP;
+
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, CommandType.HELP);
+        return new CommandResult(SHOWING_HELP_MESSAGE, HELP_COMMAND_TYPE);
     }
 }

--- a/src/main/java/seedu/uninurse/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/ListCommand.java
@@ -9,10 +9,11 @@ import seedu.uninurse.model.Model;
  * Lists all persons in the uninurse book to the user.
  */
 public class ListCommand extends Command {
-
     public static final String COMMAND_WORD = "list";
 
     public static final String MESSAGE_SUCCESS = "Listed all persons";
+
+    public static final CommandType LIST_COMMAND_TYPE = CommandType.LIST;
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/uninurse/logic/commands/ListTaskCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/ListTaskCommand.java
@@ -8,15 +8,16 @@ import seedu.uninurse.model.Model;
  * Lists all tasks associated to all patients in the uninurse book to the user.
  */
 public class ListTaskCommand extends Command {
-
     public static final String COMMAND_WORD = "listTask";
 
     public static final String MESSAGE_SUCCESS = "Listed all tasks";
+
+    public static final CommandType LIST_TASK_COMMAND_TYPE = CommandType.SCHEDULE;
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(p -> !(p.getTasks().isEmpty()));
-        return new CommandResult(MESSAGE_SUCCESS, CommandType.SCHEDULE);
+        return new CommandResult(MESSAGE_SUCCESS, LIST_TASK_COMMAND_TYPE);
     }
 }

--- a/src/main/java/seedu/uninurse/logic/commands/PatientsTodayCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/PatientsTodayCommand.java
@@ -9,17 +9,18 @@ import seedu.uninurse.model.Model;
  * Lists all patients for today.
  */
 public class PatientsTodayCommand extends Command {
-
     public static final String COMMAND_WORD = "patientsToday";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all patients with tasks today";
 
     public static final String MESSAGE_SUCCESS = "Listed all patients for today";
 
+    public static final CommandType PATIENTS_TODAY_COMMAND_TYPE = CommandType.SCHEDULE;
+
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_PATIENTS_FOR_TODAY);
-        return new CommandResult(MESSAGE_SUCCESS, CommandType.SCHEDULE);
+        return new CommandResult(MESSAGE_SUCCESS, PATIENTS_TODAY_COMMAND_TYPE);
     }
 }

--- a/src/main/java/seedu/uninurse/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/RedoCommand.java
@@ -10,11 +10,11 @@ import seedu.uninurse.model.Model;
  * Undo the last undo command.
  */
 public class RedoCommand extends Command {
-
     public static final String COMMAND_WORD = "redo";
     public static final String MESSAGE_FAILURE = "No command to redo!";
     public static final String MESSAGE_SUCCESS = "Redone next command!";
 
+    public static final CommandType REDO_COMMAND_TYPE = CommandType.REDO;
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
@@ -25,6 +25,6 @@ public class RedoCommand extends Command {
 
         model.redo();
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS, CommandType.REDO);
+        return new CommandResult(MESSAGE_SUCCESS, REDO_COMMAND_TYPE);
     }
 }

--- a/src/main/java/seedu/uninurse/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/UndoCommand.java
@@ -10,11 +10,11 @@ import seedu.uninurse.model.Model;
  * Undo the last command.
  */
 public class UndoCommand extends Command {
-
     public static final String COMMAND_WORD = "undo";
     public static final String MESSAGE_FAILURE = "Maximum undo limit reached! ";
     public static final String MESSAGE_SUCCESS = "Undone previous command!";
 
+    public static final CommandType UNDO_COMMAND_TYPE = CommandType.UNDO;
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
@@ -25,6 +25,6 @@ public class UndoCommand extends Command {
 
         model.undo();
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS, CommandType.UNDO);
+        return new CommandResult(MESSAGE_SUCCESS, UNDO_COMMAND_TYPE);
     }
 }

--- a/src/main/java/seedu/uninurse/logic/commands/ViewTaskCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/ViewTaskCommand.java
@@ -14,7 +14,6 @@ import seedu.uninurse.model.person.Patient;
  * Shows all tasks associcated with the given patient in the uninurse book to the user.
  */
 public class ViewTaskCommand extends Command {
-
     public static final String COMMAND_WORD = "viewTask";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
@@ -24,6 +23,8 @@ public class ViewTaskCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_SUCCESS = "Showing Tasks for Patient: %1$s\n%2$s";
+
+    public static final CommandType VIEW_TASK_COMMAND_TYPE = CommandType.TASK;
 
     private final Index targetIndex;
 
@@ -44,6 +45,6 @@ public class ViewTaskCommand extends Command {
         model.updateFilteredPersonList(p -> p.equals(person));
         model.setPatientOfInterest(person);
         return new CommandResult(String.format(MESSAGE_SUCCESS, person.getName(), person.getTasks().toString()),
-                CommandType.TASK);
+                VIEW_TASK_COMMAND_TYPE);
     }
 }

--- a/src/test/java/seedu/uninurse/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/AddCommandIntegrationTest.java
@@ -17,7 +17,6 @@ import seedu.uninurse.testutil.PersonBuilder;
  * Contains integration tests (interaction with the Model) for {@code AddPatientCommand}.
  */
 public class AddCommandIntegrationTest {
-
     private Model model;
 
     @BeforeEach
@@ -33,7 +32,8 @@ public class AddCommandIntegrationTest {
         expectedModel.addPerson(validPerson);
 
         assertCommandSuccess(new AddPatientCommand(validPerson), model,
-                String.format(AddPatientCommand.MESSAGE_SUCCESS, validPerson), CommandType.ADD_PATIENT, expectedModel);
+                String.format(AddPatientCommand.MESSAGE_SUCCESS, validPerson),
+                        AddPatientCommand.ADD_PATIENT_COMMAND_TYPE, expectedModel);
     }
 
     @Test
@@ -41,5 +41,4 @@ public class AddCommandIntegrationTest {
         Patient personInList = model.getUninurseBook().getPersonList().get(0);
         assertCommandFailure(new AddPatientCommand(personInList), model, AddPatientCommand.MESSAGE_DUPLICATE_PERSON);
     }
-
 }

--- a/src/test/java/seedu/uninurse/logic/commands/AddConditionCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/AddConditionCommandTest.java
@@ -64,7 +64,8 @@ public class AddConditionCommandTest {
         Model expectedModel = new ModelManager(new UninurseBook(model.getUninurseBook()), new UserPrefs());
         expectedModel.setPerson(patientToAddCondition, editedPatient);
 
-        assertCommandSuccess(addConditionCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(addConditionCommand, model, expectedMessage,
+                AddConditionCommand.ADD_CONDITION_COMMAND_TYPE, expectedModel);
     }
 
     @Test
@@ -93,7 +94,8 @@ public class AddConditionCommandTest {
         Model expectedModel = new ModelManager(new UninurseBook(model.getUninurseBook()), new UserPrefs());
         expectedModel.setPerson(patientToAddCondition, editedPatient);
 
-        assertCommandSuccess(addConditionCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(addConditionCommand, model, expectedMessage,
+                AddConditionCommand.ADD_CONDITION_COMMAND_TYPE, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/uninurse/logic/commands/AddTaskCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/AddTaskCommandTest.java
@@ -68,7 +68,8 @@ public class AddTaskCommandTest {
         expectedModel.updateFilteredPersonList(patient -> patient.equals(editedPatient));
         expectedModel.setPatientOfInterest(editedPatient);
 
-        assertCommandSuccess(addTaskCommand, model, expectedMessage, CommandType.TASK, expectedModel);
+        assertCommandSuccess(addTaskCommand, model, expectedMessage,
+                AddTaskCommand.ADD_TASK_COMMAND_TYPE, expectedModel);
     }
 
     @Test
@@ -99,7 +100,8 @@ public class AddTaskCommandTest {
         expectedModel.updateFilteredPersonList(patient -> patient.equals(editedPatient));
         expectedModel.setPatientOfInterest(editedPatient);
 
-        assertCommandSuccess(addTaskCommand, model, expectedMessage, CommandType.TASK, expectedModel);
+        assertCommandSuccess(addTaskCommand, model, expectedMessage,
+                AddTaskCommand.ADD_TASK_COMMAND_TYPE, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/uninurse/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/ClearCommandTest.java
@@ -11,13 +11,13 @@ import seedu.uninurse.model.UninurseBook;
 import seedu.uninurse.model.UserPrefs;
 
 public class ClearCommandTest {
-
     @Test
     public void execute_emptyUninurseBook_success() {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
 
-        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, CommandType.CLEAR, expectedModel);
+        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS,
+                ClearCommand.CLEAR_COMMAND_TYPE, expectedModel);
     }
 
     @Test
@@ -26,6 +26,7 @@ public class ClearCommandTest {
         Model expectedModel = new ModelManager(getTypicalUninurseBook(), new UserPrefs());
         expectedModel.setUninurseBook(new UninurseBook());
 
-        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, CommandType.CLEAR, expectedModel);
+        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS,
+                ClearCommand.CLEAR_COMMAND_TYPE, expectedModel);
     }
 }

--- a/src/test/java/seedu/uninurse/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/uninurse/logic/commands/CommandTestUtil.java
@@ -27,7 +27,6 @@ import seedu.uninurse.testutil.EditPatientDescriptorBuilder;
  * Contains helper methods for testing commands.
  */
 public class CommandTestUtil {
-
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_PHONE_AMY = "11111111";

--- a/src/test/java/seedu/uninurse/logic/commands/DeletePatientCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/DeletePatientCommandTest.java
@@ -36,7 +36,8 @@ public class DeletePatientCommandTest {
         ModelManager expectedModel = new ModelManager(model.getUninurseBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
 
-        assertCommandSuccess(deleteCommand, model, expectedMessage, CommandType.DELETE_PATIENT, expectedModel);
+        assertCommandSuccess(deleteCommand, model, expectedMessage,
+                DeletePatientCommand.DELETE_PATIENT_COMMAND_TYPE, expectedModel);
     }
 
     @Test
@@ -60,7 +61,8 @@ public class DeletePatientCommandTest {
         expectedModel.deletePerson(personToDelete);
         showNoPerson(expectedModel);
 
-        assertCommandSuccess(deleteCommand, model, expectedMessage, CommandType.DELETE_PATIENT, expectedModel);
+        assertCommandSuccess(deleteCommand, model, expectedMessage,
+                DeletePatientCommand.DELETE_PATIENT_COMMAND_TYPE, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/uninurse/logic/commands/DeleteTaskCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/DeleteTaskCommandTest.java
@@ -65,7 +65,8 @@ class DeleteTaskCommandTest {
         expectedModel.updateFilteredPersonList(patient -> patient.equals(editedPatient));
         expectedModel.setPatientOfInterest(editedPatient);
 
-        assertCommandSuccess(deleteTaskCommand, model, expectedMessage, CommandType.TASK, expectedModel);
+        assertCommandSuccess(deleteTaskCommand, model, expectedMessage,
+                DeleteTaskCommand.DELETE_TASK_COMMAND_TYPE, expectedModel);
     }
 
     @Test
@@ -96,7 +97,8 @@ class DeleteTaskCommandTest {
         expectedModel.updateFilteredPersonList(patient -> patient.equals(editedPatient));
         expectedModel.setPatientOfInterest(editedPatient);
 
-        assertCommandSuccess(deleteTaskCommand, model, expectedMessage, CommandType.TASK, expectedModel);
+        assertCommandSuccess(deleteTaskCommand, model, expectedMessage,
+                DeleteTaskCommand.DELETE_TASK_COMMAND_TYPE, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/uninurse/logic/commands/EditPatientCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/EditPatientCommandTest.java
@@ -31,7 +31,6 @@ import seedu.uninurse.testutil.PersonBuilder;
  * Contains integration tests (interaction with the Model) and unit tests for EditPatientCommand.
  */
 public class EditPatientCommandTest {
-
     private Model model = new ModelManager(getTypicalUninurseBook(), new UserPrefs());
 
     @Test
@@ -45,7 +44,8 @@ public class EditPatientCommandTest {
         Model expectedModel = new ModelManager(new UninurseBook(model.getUninurseBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
 
-        assertCommandSuccess(editPatientCommand, model, expectedMessage, CommandType.EDIT_PATIENT, expectedModel);
+        assertCommandSuccess(editPatientCommand, model, expectedMessage,
+                EditPatientCommand.EDIT_PATIENT_COMMAND_TYPE, expectedModel);
     }
 
     @Test
@@ -66,7 +66,8 @@ public class EditPatientCommandTest {
         Model expectedModel = new ModelManager(new UninurseBook(model.getUninurseBook()), new UserPrefs());
         expectedModel.setPerson(lastPerson, editedPerson);
 
-        assertCommandSuccess(editPatientCommand, model, expectedMessage, CommandType.EDIT_PATIENT, expectedModel);
+        assertCommandSuccess(editPatientCommand, model, expectedMessage,
+                EditPatientCommand.EDIT_PATIENT_COMMAND_TYPE, expectedModel);
     }
 
     @Test
@@ -78,7 +79,8 @@ public class EditPatientCommandTest {
 
         Model expectedModel = new ModelManager(new UninurseBook(model.getUninurseBook()), new UserPrefs());
 
-        assertCommandSuccess(editPatientCommand, model, expectedMessage, CommandType.EDIT_PATIENT, expectedModel);
+        assertCommandSuccess(editPatientCommand, model, expectedMessage,
+                EditPatientCommand.EDIT_PATIENT_COMMAND_TYPE, expectedModel);
     }
 
     @Test
@@ -95,7 +97,8 @@ public class EditPatientCommandTest {
         Model expectedModel = new ModelManager(new UninurseBook(model.getUninurseBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
 
-        assertCommandSuccess(editPatientCommand, model, expectedMessage, CommandType.EDIT_PATIENT, expectedModel);
+        assertCommandSuccess(editPatientCommand, model, expectedMessage,
+                EditPatientCommand.EDIT_PATIENT_COMMAND_TYPE, expectedModel);
     }
 
     @Test
@@ -169,5 +172,4 @@ public class EditPatientCommandTest {
         // different descriptor -> returns false
         assertFalse(standardCommand.equals(new EditPatientCommand(INDEX_FIRST_PERSON, DESC_BOB)));
     }
-
 }

--- a/src/test/java/seedu/uninurse/logic/commands/EditTaskCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/EditTaskCommandTest.java
@@ -29,7 +29,6 @@ import seedu.uninurse.testutil.PersonBuilder;
  * Contains integration tests (interaction with the Model) and unit tests for {@code EditTaskCommand}.
  */
 class EditTaskCommandTest {
-
     private static final String TASK_STUB = "Some task";
 
     private final Model model = new ModelManager(getTypicalUninurseBook(), new UserPrefs());
@@ -79,7 +78,8 @@ class EditTaskCommandTest {
         expectedModel.updateFilteredPersonList(patient -> patient.equals(editedPatient));
         expectedModel.setPatientOfInterest(editedPatient);
 
-        assertCommandSuccess(editTaskCommand, model, expectedMessage, CommandType.TASK, expectedModel);
+        assertCommandSuccess(editTaskCommand, model, expectedMessage,
+                EditTaskCommand.EDIT_TASK_COMMAND_TYPE, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/uninurse/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/ExitCommandTest.java
@@ -14,7 +14,8 @@ public class ExitCommandTest {
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, CommandType.EXIT);
+        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT,
+                ExitCommand.EXIT_COMMAND_TYPE);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/uninurse/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/FindCommandTest.java
@@ -60,7 +60,7 @@ public class FindCommandTest {
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, CommandType.FIND, expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, FindCommand.FIND_COMMAND_TYPE, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
     }
 
@@ -70,7 +70,7 @@ public class FindCommandTest {
         NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, CommandType.FIND, expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, FindCommand.FIND_COMMAND_TYPE, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
     }
 

--- a/src/test/java/seedu/uninurse/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/HelpCommandTest.java
@@ -14,7 +14,7 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, CommandType.HELP);
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, HelpCommand.HELP_COMMAND_TYPE);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/uninurse/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/ListCommandTest.java
@@ -28,12 +28,14 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, CommandType.LIST, expectedModel);
+        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS,
+                ListCommand.LIST_COMMAND_TYPE, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, CommandType.LIST, expectedModel);
+        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS,
+                ListCommand.LIST_COMMAND_TYPE, expectedModel);
     }
 }

--- a/src/test/java/seedu/uninurse/logic/commands/PatientsTodayCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/PatientsTodayCommandTest.java
@@ -29,7 +29,7 @@ class PatientsTodayCommandTest {
     public void execute_noPatientsToday_showsNoPatients() {
         expectedModel.updateFilteredPersonList(Model.PREDICATE_SHOW_PATIENTS_FOR_TODAY);
         assertCommandSuccess(new PatientsTodayCommand(), model, PatientsTodayCommand.MESSAGE_SUCCESS,
-                CommandType.SCHEDULE, expectedModel);
+                PatientsTodayCommand.PATIENTS_TODAY_COMMAND_TYPE, expectedModel);
     }
 
     @Test
@@ -41,6 +41,6 @@ class PatientsTodayCommandTest {
         CommandResult addCommand2 = new AddPatientCommand(patientForToday).execute(expectedModel);
         expectedModel.updateFilteredPersonList(Model.PREDICATE_SHOW_PATIENTS_FOR_TODAY);
         assertCommandSuccess(new PatientsTodayCommand(), model, PatientsTodayCommand.MESSAGE_SUCCESS,
-                CommandType.SCHEDULE, expectedModel);
+                PatientsTodayCommand.PATIENTS_TODAY_COMMAND_TYPE, expectedModel);
     }
 }


### PR DESCRIPTION
This PR standardizes the usage of `CommandType` in `Command`s by declaring them as class level attributes.