### PR TITLE
Fix instances of patient modification in commands

### DIFF
--- a/src/main/java/seedu/uninurse/logic/commands/AddConditionCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/AddConditionCommand.java
@@ -58,9 +58,7 @@ public class AddConditionCommand extends AddGenericCommand {
 
         Patient patientToEdit = lastShownList.get(index.getZeroBased());
         ConditionList updatedConditionList = patientToEdit.getConditions().add(condition);
-        Patient editedPatient = new Patient(
-                patientToEdit.getName(), patientToEdit.getPhone(), patientToEdit.getEmail(),
-                patientToEdit.getAddress(), updatedConditionList, patientToEdit.getTasks(), patientToEdit.getTags());
+        Patient editedPatient = new Patient(patientToEdit, updatedConditionList);
 
         model.setPerson(patientToEdit, editedPatient);
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/seedu/uninurse/logic/commands/AddTaskCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/AddTaskCommand.java
@@ -55,7 +55,9 @@ public class AddTaskCommand extends AddGenericCommand {
         }
 
         Patient personToEdit = lastShownList.get(index.getZeroBased());
+
         TaskList updatedTaskList = personToEdit.getTasks().add(task);
+
         Patient editedPerson = new Patient(personToEdit, updatedTaskList);
 
         model.setPerson(personToEdit, editedPerson);

--- a/src/main/java/seedu/uninurse/logic/commands/AddTaskCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/AddTaskCommand.java
@@ -56,9 +56,7 @@ public class AddTaskCommand extends AddGenericCommand {
 
         Patient personToEdit = lastShownList.get(index.getZeroBased());
         TaskList updatedTaskList = personToEdit.getTasks().add(task);
-        Patient editedPerson = new Patient(
-                personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(), personToEdit.getAddress(),
-                personToEdit.getConditions(), updatedTaskList, personToEdit.getTags());
+        Patient editedPerson = new Patient(personToEdit, updatedTaskList);
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(patient -> patient.equals(editedPerson));

--- a/src/main/java/seedu/uninurse/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/DeleteTaskCommand.java
@@ -54,14 +54,13 @@ public class DeleteTaskCommand extends DeleteGenericCommand {
         }
 
         Patient patientToEdit = lastShownList.get(patientIndex.getZeroBased());
-        TaskList initialTaskList = patientToEdit.getTasks();
 
-        if (taskIndex.getZeroBased() >= initialTaskList.size()) {
+        if (taskIndex.getZeroBased() >= patientToEdit.getTasks().size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_TASK_INDEX);
         }
 
+        Task deletedTask = patientToEdit.getTasks().get(taskIndex.getZeroBased());
         TaskList updatedTaskList = patientToEdit.getTasks().delete(taskIndex.getZeroBased());
-        Task deletedTask = initialTaskList.get(taskIndex.getZeroBased());
 
         Patient editedPerson = new Patient(patientToEdit, updatedTaskList);
 

--- a/src/main/java/seedu/uninurse/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/DeleteTaskCommand.java
@@ -63,9 +63,7 @@ public class DeleteTaskCommand extends DeleteGenericCommand {
         TaskList updatedTaskList = patientToEdit.getTasks().delete(taskIndex.getZeroBased());
         Task deletedTask = initialTaskList.get(taskIndex.getZeroBased());
 
-        Patient editedPerson = new Patient(
-                patientToEdit.getName(), patientToEdit.getPhone(), patientToEdit.getEmail(),
-                patientToEdit.getAddress(), patientToEdit.getConditions(), updatedTaskList, patientToEdit.getTags());
+        Patient editedPerson = new Patient(patientToEdit, updatedTaskList);
 
         model.setPerson(patientToEdit, editedPerson);
         model.updateFilteredPersonList(patient -> patient.equals(editedPerson));

--- a/src/main/java/seedu/uninurse/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/DeleteTaskCommand.java
@@ -24,7 +24,7 @@ public class DeleteTaskCommand extends DeleteGenericCommand {
             + "TASK_INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1 2";
 
-    public static final String MESSAGE_DELETE_TASK_SUCCESS = "Deleted task from %1$s: %2$s";
+    public static final String MESSAGE_DELETE_TASK_SUCCESS = "Deleted task %1$d from %2$s: %3$s";
 
     public static final CommandType DELETE_TASK_COMMAND_TYPE = CommandType.TASK;
 
@@ -68,8 +68,8 @@ public class DeleteTaskCommand extends DeleteGenericCommand {
         model.updateFilteredPersonList(patient -> patient.equals(editedPerson));
         model.setPatientOfInterest(editedPerson);
 
-        return new CommandResult(String.format(MESSAGE_DELETE_TASK_SUCCESS, editedPerson.getName(), deletedTask),
-                DELETE_TASK_COMMAND_TYPE);
+        return new CommandResult(String.format(MESSAGE_DELETE_TASK_SUCCESS,
+                taskIndex.getOneBased(), editedPerson.getName(), deletedTask), DELETE_TASK_COMMAND_TYPE);
     }
 
     @Override

--- a/src/main/java/seedu/uninurse/logic/commands/EditTaskCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/EditTaskCommand.java
@@ -25,7 +25,9 @@ public class EditTaskCommand extends EditGenericCommand {
             + "Example: " + COMMAND_WORD + " 1 " + " 2 "
             + PREFIX_TASK_DESCRIPTION + "change bandage";
 
-    public static final String MESSAGE_EDIT_TASK_SUCCESS = "Edited Task: %1$s -> %2$s";
+    public static final String MESSAGE_EDIT_TASK_SUCCESS = "Edited task %1$d of %2$s:\n"
+            + "Before: %3$s\n"
+            + "After: %4$s";
     public static final String MESSAGE_NOT_EDITED = "Task to edit must be provided.";
 
     public static final CommandType EDIT_TASK_COMMAND_TYPE = CommandType.TASK;
@@ -73,8 +75,8 @@ public class EditTaskCommand extends EditGenericCommand {
         model.updateFilteredPersonList(patient -> patient.equals(editedPatient));
         model.setPatientOfInterest(editedPatient);
 
-        return new CommandResult(String.format(MESSAGE_EDIT_TASK_SUCCESS, initialTask, updatedTask),
-                EDIT_TASK_COMMAND_TYPE);
+        return new CommandResult(String.format(MESSAGE_EDIT_TASK_SUCCESS,
+                taskIndex.getOneBased(), editedPatient.getName(), initialTask, updatedTask), EDIT_TASK_COMMAND_TYPE);
     }
 
     @Override

--- a/src/main/java/seedu/uninurse/logic/commands/EditTaskCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/EditTaskCommand.java
@@ -25,7 +25,7 @@ public class EditTaskCommand extends EditGenericCommand {
             + "Example: " + COMMAND_WORD + " 1 " + " 2 "
             + PREFIX_TASK_DESCRIPTION + "change bandage";
 
-    public static final String MESSAGE_EDIT_TASK_SUCCESS = "Edited Task: %1$s";
+    public static final String MESSAGE_EDIT_TASK_SUCCESS = "Edited Task: %1$s -> %2$s";
     public static final String MESSAGE_NOT_EDITED = "Task to edit must be provided.";
 
     public static final CommandType EDIT_TASK_COMMAND_TYPE = CommandType.TASK;
@@ -63,14 +63,17 @@ public class EditTaskCommand extends EditGenericCommand {
         if (taskIndex.getZeroBased() >= patientToEdit.getTasks().size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_TASK_INDEX);
         }
+
+        Task initialTask = patientToEdit.getTasks().get(taskIndex.getZeroBased());
         TaskList updatedTaskList = patientToEdit.getTasks().edit(taskIndex.getZeroBased(), updatedTask);
+
         Patient editedPatient = new Patient(patientToEdit, updatedTaskList);
 
         model.setPerson(patientToEdit, editedPatient);
         model.updateFilteredPersonList(patient -> patient.equals(editedPatient));
         model.setPatientOfInterest(editedPatient);
 
-        return new CommandResult(String.format(MESSAGE_EDIT_TASK_SUCCESS, editedPatient),
+        return new CommandResult(String.format(MESSAGE_EDIT_TASK_SUCCESS, initialTask, updatedTask),
                 EDIT_TASK_COMMAND_TYPE);
     }
 

--- a/src/main/java/seedu/uninurse/logic/commands/EditTaskCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/EditTaskCommand.java
@@ -4,19 +4,12 @@ import static java.util.Objects.requireNonNull;
 import static seedu.uninurse.logic.parser.CliSyntax.PREFIX_TASK_DESCRIPTION;
 
 import java.util.List;
-import java.util.Set;
 
 import seedu.uninurse.commons.core.Messages;
 import seedu.uninurse.commons.core.index.Index;
 import seedu.uninurse.logic.commands.exceptions.CommandException;
 import seedu.uninurse.model.Model;
-import seedu.uninurse.model.condition.ConditionList;
-import seedu.uninurse.model.person.Address;
-import seedu.uninurse.model.person.Email;
-import seedu.uninurse.model.person.Name;
 import seedu.uninurse.model.person.Patient;
-import seedu.uninurse.model.person.Phone;
-import seedu.uninurse.model.tag.Tag;
 import seedu.uninurse.model.task.Task;
 import seedu.uninurse.model.task.TaskList;
 
@@ -70,37 +63,15 @@ public class EditTaskCommand extends EditGenericCommand {
         if (taskIndex.getZeroBased() >= patientToEdit.getTasks().size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_TASK_INDEX);
         }
-
-        Patient editedPatient = createEditedPatient(patientToEdit, taskIndex, updatedTask);
+        TaskList updatedTaskList = patientToEdit.getTasks().edit(taskIndex.getZeroBased(), updatedTask);
+        Patient editedPatient = new Patient(patientToEdit, updatedTaskList);
 
         model.setPerson(patientToEdit, editedPatient);
         model.updateFilteredPersonList(patient -> patient.equals(editedPatient));
         model.setPatientOfInterest(editedPatient);
+
         return new CommandResult(String.format(MESSAGE_EDIT_TASK_SUCCESS, editedPatient),
                 EDIT_TASK_COMMAND_TYPE);
-    }
-
-    /**
-     * Creates an edited person with the updated Task.
-     *
-     * @param patientToEdit the patient associated with the task to edit.
-     * @param indexOfTask the index of the task to be edited.
-     * @param updatedTask the new task details to be edited with.
-     * @return a person with the updated task details.
-     */
-    private static Patient createEditedPatient(Patient patientToEdit, Index indexOfTask, Task updatedTask) {
-        assert patientToEdit != null;
-
-        Name name = patientToEdit.getName();
-        Phone phone = patientToEdit.getPhone();
-        Email email = patientToEdit.getEmail();
-        Address address = patientToEdit.getAddress();
-        ConditionList conditions = patientToEdit.getConditions();
-        Set<Tag> tags = patientToEdit.getTags();
-
-        TaskList updatedTaskList = patientToEdit.getTasks().edit(indexOfTask.getZeroBased(), updatedTask);
-
-        return new Patient(name, phone, email, address, conditions, updatedTaskList, tags);
     }
 
     @Override

--- a/src/main/java/seedu/uninurse/model/person/Patient.java
+++ b/src/main/java/seedu/uninurse/model/person/Patient.java
@@ -30,6 +30,28 @@ public class Patient extends Person {
         this.tasks = tasks;
     }
 
+    /**
+     * Used to return a new immutable {@code Patient} when {@code ConditionList} is updated.
+     * @param patient the patient to be updated
+     * @param condupdatedConditionsitions the updated conditions.
+     */
+    public Patient(Patient patient, ConditionList updatedConditions) {
+        super(patient);
+        this.conditions = updatedConditions;
+        this.tasks = patient.tasks;
+    }
+
+    /**
+     * Used to return a new immutable {@code Patient} when {@code TaskList} is updated.
+     * @param patient the patient to be updated
+     * @param updatedTasks the updated tasks.
+     */
+    public Patient(Patient patient, TaskList updatedTasks) {
+        super(patient);
+        this.conditions = patient.conditions;
+        this.tasks = updatedTasks;
+    }
+
     public ConditionList getConditions() {
         return conditions;
     }
@@ -111,5 +133,4 @@ public class Patient extends Person {
         }
         return builder.toString();
     }
-
 }

--- a/src/main/java/seedu/uninurse/model/person/Patient.java
+++ b/src/main/java/seedu/uninurse/model/person/Patient.java
@@ -33,7 +33,7 @@ public class Patient extends Person {
     /**
      * Used to return a new immutable {@code Patient} when {@code ConditionList} is updated.
      * @param patient the patient to be updated
-     * @param condupdatedConditionsitions the updated conditions.
+     * @param updatedConditions the updated conditions.
      */
     public Patient(Patient patient, ConditionList updatedConditions) {
         super(patient);

--- a/src/main/java/seedu/uninurse/model/person/Person.java
+++ b/src/main/java/seedu/uninurse/model/person/Person.java
@@ -1,5 +1,6 @@
 package seedu.uninurse.model.person;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.uninurse.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Collections;
@@ -9,13 +10,11 @@ import java.util.Set;
 
 import seedu.uninurse.model.tag.Tag;
 
-
 /**
  * Represents a Person in the uninurse book.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class Person {
-
     // Identity fields
     private final Name name;
     private final Phone phone;
@@ -35,6 +34,18 @@ public class Person {
         this.email = email;
         this.address = address;
         this.tags.addAll(tags);
+    }
+
+    /**
+     * Used to return a new immutable {@code Person} when provided with a {@code Person}.
+     */
+    public Person(Person person) {
+        requireNonNull(person);
+        this.name = person.name;
+        this.phone = person.phone;
+        this.email = person.email;
+        this.address = person.address;
+        this.tags.addAll(person.tags);
     }
 
     public Name getName() {

--- a/src/test/java/seedu/uninurse/logic/commands/DeleteTaskCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/DeleteTaskCommandTest.java
@@ -58,7 +58,7 @@ class DeleteTaskCommandTest {
         DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(INDEX_THIRD_PERSON, INDEX_FIRST_TASK);
 
         String expectedMessage = String.format(DeleteTaskCommand.MESSAGE_DELETE_TASK_SUCCESS,
-                editedPatient.getName().toString(), deletedTask);
+                INDEX_FIRST_TASK.getOneBased(), editedPatient.getName().toString(), deletedTask);
 
         Model expectedModel = new ModelManager(new UninurseBook(model.getUninurseBook()), new UserPrefs());
         expectedModel.setPerson(patientToDeleteTask, editedPatient);
@@ -90,7 +90,7 @@ class DeleteTaskCommandTest {
         DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(INDEX_FIRST_PERSON, INDEX_FIRST_TASK);
 
         String expectedMessage = String.format(DeleteTaskCommand.MESSAGE_DELETE_TASK_SUCCESS,
-                editedPatient.getName().toString(), deletedTask);
+                INDEX_FIRST_TASK.getOneBased(), editedPatient.getName().toString(), deletedTask);
 
         Model expectedModel = new ModelManager(new UninurseBook(model.getUninurseBook()), new UserPrefs());
         expectedModel.setPerson(patientToDeleteTask, editedPatient);

--- a/src/test/java/seedu/uninurse/logic/commands/EditTaskCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/EditTaskCommandTest.java
@@ -73,7 +73,8 @@ class EditTaskCommandTest {
 
         EditTaskCommand editTaskCommand = new EditTaskCommand(INDEX_SECOND_PERSON, INDEX_FIRST_TASK, editedTask);
 
-        String expectedMessage = String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, initialTask, editedTask);
+        String expectedMessage = String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS,
+                INDEX_FIRST_TASK.getOneBased(), editedPatient.getName().toString(), initialTask, editedTask);
 
         Model expectedModel = new ModelManager(new UninurseBook(model.getUninurseBook()), new UserPrefs());
         expectedModel.setPerson(secondPatient, editedPatient);

--- a/src/test/java/seedu/uninurse/logic/commands/EditTaskCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/EditTaskCommandTest.java
@@ -59,10 +59,12 @@ class EditTaskCommandTest {
 
     @Test
     public void execute_editTask_success() {
-        Task editedTask = new Task(TASK_STUB);
-
         // Use second patient as the first patient in typical persons does not have a task
         Patient secondPatient = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+
+        Task initialTask = secondPatient.getTasks().get(INDEX_FIRST_TASK.getZeroBased());
+        Task editedTask = new Task(TASK_STUB);
+
         Patient editedPatient = new PersonBuilder(secondPatient)
                 .withTasks(secondPatient.getTasks().edit(INDEX_FIRST_TASK.getZeroBased(), editedTask)
                         .getTasks().toArray(Task[]::new))
@@ -71,7 +73,7 @@ class EditTaskCommandTest {
 
         EditTaskCommand editTaskCommand = new EditTaskCommand(INDEX_SECOND_PERSON, INDEX_FIRST_TASK, editedTask);
 
-        String expectedMessage = String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, editedPatient);
+        String expectedMessage = String.format(EditTaskCommand.MESSAGE_EDIT_TASK_SUCCESS, initialTask, editedTask);
 
         Model expectedModel = new ModelManager(new UninurseBook(model.getUninurseBook()), new UserPrefs());
         expectedModel.setPerson(secondPatient, editedPatient);


### PR DESCRIPTION
Closes #233, #237
This PR fixes patient modification by creating new overloaded constructors that returns a new immutable patient with the specified updated list (e.g. `ConditionList` or `TaskLIst`).

Inconsistencies in `EditTaskCommand` and `DeleteTaskCommand` are also addressed.