### PR TITLE
Fix GUI update for `addCondition` command

### DIFF
--- a/src/main/java/seedu/uninurse/logic/commands/AddConditionCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/AddConditionCommand.java
@@ -11,7 +11,6 @@ import seedu.uninurse.logic.commands.exceptions.CommandException;
 import seedu.uninurse.model.Model;
 import seedu.uninurse.model.condition.Condition;
 import seedu.uninurse.model.condition.ConditionList;
-import seedu.uninurse.model.condition.exceptions.ConditionNotFoundException;
 import seedu.uninurse.model.condition.exceptions.DuplicateConditionException;
 import seedu.uninurse.model.person.Patient;
 
@@ -63,7 +62,7 @@ public class AddConditionCommand extends AddGenericCommand {
 
         try {
             updatedConditionList = patientToEdit.getConditions().add(condition);
-        } catch(DuplicateConditionException exception) {
+        } catch (DuplicateConditionException exception) {
             throw new CommandException(exception.getMessage());
         }
 

--- a/src/main/java/seedu/uninurse/logic/commands/AddConditionCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/AddConditionCommand.java
@@ -11,6 +11,8 @@ import seedu.uninurse.logic.commands.exceptions.CommandException;
 import seedu.uninurse.model.Model;
 import seedu.uninurse.model.condition.Condition;
 import seedu.uninurse.model.condition.ConditionList;
+import seedu.uninurse.model.condition.exceptions.ConditionNotFoundException;
+import seedu.uninurse.model.condition.exceptions.DuplicateConditionException;
 import seedu.uninurse.model.person.Patient;
 
 /**
@@ -57,11 +59,19 @@ public class AddConditionCommand extends AddGenericCommand {
         }
 
         Patient patientToEdit = lastShownList.get(index.getZeroBased());
-        ConditionList updatedConditionList = patientToEdit.getConditions().add(condition);
+        ConditionList updatedConditionList;
+
+        try {
+            updatedConditionList = patientToEdit.getConditions().add(condition);
+        } catch(DuplicateConditionException exception) {
+            throw new CommandException(exception.getMessage());
+        }
+
         Patient editedPatient = new Patient(patientToEdit, updatedConditionList);
 
         model.setPerson(patientToEdit, editedPatient);
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+        model.setPatientOfInterest(editedPatient);
 
         return new CommandResult(String.format(MESSAGE_ADD_CONDITION_SUCCESS, editedPatient.getName(), condition),
                 ADD_CONDITION_COMMAND_TYPE);


### PR DESCRIPTION
closes #246.

This PR addresses the issue that the GUI does not update after the `addCondition` command.
The fix is to call `model#setPatientOfInterest()` in the command as such.
```java
model.setPerson(patientToEdit, editedPatient);
model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
model.setPatientOfInterest(editedPatient); //add this line
```

In future commands where attributes are modified, add this line to allow the GUI to update when necessary.

Another thing to mention is that whenever `GenericList<T>` throws an exception (such as `DuplicateConditionException` in `ConditionList`), explicitly catch such exceptions and throw it as a new `CommandException` or else the GUI will not display the exception.