### PR TITLE
Feature: delete medication

### DIFF
--- a/src/main/java/seedu/uninurse/commons/core/Messages.java
+++ b/src/main/java/seedu/uninurse/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_MEDICATION_INDEX = "The medication index provided is invalid";
     public static final String MESSAGE_INVALID_TASK_INDEX = "The task index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 

--- a/src/main/java/seedu/uninurse/logic/commands/AddMedicationCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/AddMedicationCommand.java
@@ -71,7 +71,6 @@ public class AddMedicationCommand extends AddGenericCommand {
         Patient editedPatient = new Patient(patientToEdit, updatedMedicationList);
 
         model.setPerson(patientToEdit, editedPatient);
-        model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
         model.setPatientOfInterest(editedPatient);
 
         return new CommandResult(String.format(MESSAGE_ADD_MEDICATION_SUCCESS, editedPatient.getName(), medication),
@@ -91,7 +90,7 @@ public class AddMedicationCommand extends AddGenericCommand {
         }
 
         // state check
-        AddMedicationCommand e = (AddMedicationCommand) other;
-        return index.equals(e.index) && medication.equals((e.medication));
+        AddMedicationCommand command = (AddMedicationCommand) other;
+        return index.equals(command.index) && medication.equals((command.medication));
     }
 }

--- a/src/main/java/seedu/uninurse/logic/commands/DeleteMedicationCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/DeleteMedicationCommand.java
@@ -1,0 +1,94 @@
+package seedu.uninurse.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.uninurse.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.List;
+
+import seedu.uninurse.commons.core.Messages;
+import seedu.uninurse.commons.core.index.Index;
+import seedu.uninurse.logic.commands.exceptions.CommandException;
+import seedu.uninurse.model.Model;
+import seedu.uninurse.model.medication.Medication;
+import seedu.uninurse.model.medication.MedicationList;
+import seedu.uninurse.model.person.Patient;
+
+/**
+ * Deletes a medication from a patient identified using its displayed index from the patient list.
+ */
+public class DeleteMedicationCommand extends DeleteGenericCommand {
+    // tentative syntax; TODO: integrate with DeleteGenericCommand
+    public static final String COMMAND_WORD = "deleteMedication";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the medication identified by the index number in the medication list of the patient "
+            + "identified by the index number used in the last patient listing.\n"
+            + "Parameters: PATIENT_INDEX (must be a positive integer) "
+            + "MEDICATION_INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1 2";
+
+    public static final String MESSAGE_DELETE_MEDICATION_SUCCESS = "Deleted medication %1$d from %2$s: %3$s";
+
+    public static final CommandType DELETE_MEDICATION_COMMAND_TYPE = CommandType.EDIT_PATIENT;
+
+    private final Index patientIndex;
+    private final Index medicationIndex;
+
+    /**
+     * Creates an DeleteMedicationCommand to delete a {@code Medication} from the specified patient.
+     *
+     * @param patientIndex The index of the patient in the filtered person list to delete the medication.
+     * @param medicationIndex The index of the medication in the patient's medication list.
+     */
+    public DeleteMedicationCommand(Index patientIndex, Index medicationIndex) {
+        requireAllNonNull(patientIndex, medicationIndex);
+
+        this.patientIndex = patientIndex;
+        this.medicationIndex = medicationIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Patient> lastShownList = model.getFilteredPersonList();
+
+        if (patientIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Patient patientToEdit = lastShownList.get(patientIndex.getZeroBased());
+        MedicationList initialMedicationList = patientToEdit.getMedications();
+
+        if (medicationIndex.getZeroBased() >= initialMedicationList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_MEDICATION_INDEX);
+        }
+
+        MedicationList updatedMedicationList = initialMedicationList.delete(medicationIndex.getZeroBased());
+        Medication deletedMedication = initialMedicationList.get(medicationIndex.getZeroBased());
+
+        Patient editedPatient = new Patient(patientToEdit, updatedMedicationList);
+
+        model.setPerson(patientToEdit, editedPatient);
+        model.setPatientOfInterest(editedPatient);
+
+        return new CommandResult(String.format(MESSAGE_DELETE_MEDICATION_SUCCESS, medicationIndex.getOneBased(),
+                editedPatient.getName(), deletedMedication), DELETE_MEDICATION_COMMAND_TYPE);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DeleteMedicationCommand)) {
+            return false;
+        }
+
+        // state check
+        DeleteMedicationCommand command = (DeleteMedicationCommand) other;
+        return patientIndex.equals(command.patientIndex) && medicationIndex.equals((command.medicationIndex));
+    }
+}

--- a/src/main/java/seedu/uninurse/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/DeleteTaskCommand.java
@@ -54,13 +54,14 @@ public class DeleteTaskCommand extends DeleteGenericCommand {
         }
 
         Patient patientToEdit = lastShownList.get(patientIndex.getZeroBased());
+        TaskList initialTaskList = patientToEdit.getTasks();
 
-        if (taskIndex.getZeroBased() >= patientToEdit.getTasks().size()) {
+        if (taskIndex.getZeroBased() >= initialTaskList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_TASK_INDEX);
         }
 
-        Task deletedTask = patientToEdit.getTasks().get(taskIndex.getZeroBased());
-        TaskList updatedTaskList = patientToEdit.getTasks().delete(taskIndex.getZeroBased());
+        Task deletedTask = initialTaskList.get(taskIndex.getZeroBased());
+        TaskList updatedTaskList = initialTaskList.delete(taskIndex.getZeroBased());
 
         Patient editedPerson = new Patient(patientToEdit, updatedTaskList);
 

--- a/src/main/java/seedu/uninurse/logic/commands/EditTaskCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/EditTaskCommand.java
@@ -61,13 +61,14 @@ public class EditTaskCommand extends EditGenericCommand {
         }
 
         Patient patientToEdit = lastShownList.get(patientIndex.getZeroBased());
+        TaskList initialTaskList = patientToEdit.getTasks();
 
-        if (taskIndex.getZeroBased() >= patientToEdit.getTasks().size()) {
+        if (taskIndex.getZeroBased() >= initialTaskList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_TASK_INDEX);
         }
 
-        Task initialTask = patientToEdit.getTasks().get(taskIndex.getZeroBased());
-        TaskList updatedTaskList = patientToEdit.getTasks().edit(taskIndex.getZeroBased(), updatedTask);
+        Task initialTask = initialTaskList.get(taskIndex.getZeroBased());
+        TaskList updatedTaskList = initialTaskList.edit(taskIndex.getZeroBased(), updatedTask);
 
         Patient editedPatient = new Patient(patientToEdit, updatedTaskList);
 

--- a/src/main/java/seedu/uninurse/logic/parser/DeleteMedicationCommandParser.java
+++ b/src/main/java/seedu/uninurse/logic/parser/DeleteMedicationCommandParser.java
@@ -1,0 +1,38 @@
+package seedu.uninurse.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.uninurse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.List;
+
+import seedu.uninurse.commons.core.index.Index;
+import seedu.uninurse.logic.commands.DeleteMedicationCommand;
+import seedu.uninurse.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeleteMedicationCommand object.
+ */
+public class DeleteMedicationCommandParser implements Parser<DeleteMedicationCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteMedicationCommand
+     * and returns a DeleteMedicationCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteMedicationCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args);
+
+        List<Index> indices;
+
+        try {
+            indices = ParserUtil.parseTwoIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMedicationCommand.MESSAGE_USAGE), pe);
+        }
+
+        return new DeleteMedicationCommand(indices.get(0), indices.get(1));
+    }
+}

--- a/src/main/java/seedu/uninurse/logic/parser/UninurseBookParser.java
+++ b/src/main/java/seedu/uninurse/logic/parser/UninurseBookParser.java
@@ -12,6 +12,7 @@ import seedu.uninurse.logic.commands.AddMedicationCommand;
 import seedu.uninurse.logic.commands.ClearCommand;
 import seedu.uninurse.logic.commands.Command;
 import seedu.uninurse.logic.commands.DeleteGenericCommand;
+import seedu.uninurse.logic.commands.DeleteMedicationCommand;
 import seedu.uninurse.logic.commands.EditGenericCommand;
 import seedu.uninurse.logic.commands.ExitCommand;
 import seedu.uninurse.logic.commands.FindCommand;
@@ -69,6 +70,9 @@ public class UninurseBookParser {
 
         case AddMedicationCommand.COMMAND_WORD: // TODO: integrate with AddGenericCommand
             return new AddMedicationCommandParser().parse(arguments);
+
+        case DeleteMedicationCommand.COMMAND_WORD: // TODO: integrate with DeleteGenericCommand
+            return new DeleteMedicationCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/seedu/uninurse/model/medication/Medication.java
+++ b/src/main/java/seedu/uninurse/model/medication/Medication.java
@@ -54,7 +54,7 @@ public class Medication {
 
     @Override
     public String toString() {
-        return medicationType + " \\| " + medicationDosage;
+        return medicationType + " | " + medicationDosage;
     }
 
     @Override

--- a/src/main/java/seedu/uninurse/model/person/Patient.java
+++ b/src/main/java/seedu/uninurse/model/person/Patient.java
@@ -142,6 +142,12 @@ public class Patient extends Person {
                     .append(conditions);
         }
 
+        MedicationList medications = getMedications();
+        if (!medications.isEmpty()) {
+            builder.append("\nMedications:\n")
+                    .append(medications);
+        }
+
         TaskList tasks = getTasks();
         if (!tasks.isEmpty()) {
             builder.append("\nTasks:\n")

--- a/src/main/java/seedu/uninurse/ui/UpdatedPatientCard.java
+++ b/src/main/java/seedu/uninurse/ui/UpdatedPatientCard.java
@@ -70,7 +70,7 @@ public class UpdatedPatientCard extends UiPart<Region> {
                 .forEach(tag -> tags.getChildren().add(new Label(tag.getValue())));
         header.setText(headerString);
         conditions.setText("Conditions:" + "\n" + patient.getConditions().toString());
-        medications.setText("Medications:" + "\n" + "1. enlarger with also a really really long name"); //dummy values
+        medications.setText("Medications:" + "\n" + patient.getMedications().toString());
         taskheader.setText("Tasks:");
         tasklist.setText(patient.getTasks().toString());
     }

--- a/src/test/java/seedu/uninurse/logic/commands/AddMedicationCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/AddMedicationCommandTest.java
@@ -92,6 +92,7 @@ public class AddMedicationCommandTest {
                 editedPatient.getName(), medicationToAdd);
 
         Model expectedModel = new ModelManager(new UninurseBook(model.getUninurseBook()), new UserPrefs());
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
         expectedModel.setPerson(patientToAddMedication, editedPatient);
 
         assertCommandSuccess(addMedicationCommand, model, expectedMessage,

--- a/src/test/java/seedu/uninurse/logic/commands/DeleteMedicationCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/DeleteMedicationCommandTest.java
@@ -58,7 +58,8 @@ public class DeleteMedicationCommandTest {
         // use second person in TypicalPersons since there is one medication to delete
         Patient patientToDeleteMedication = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
         Patient editedPatient = new PersonBuilder(patientToDeleteMedication).withMedications().build();
-        Medication deletedMedication = patientToDeleteMedication.getMedications().get(INDEX_FIRST_ATTRIBUTE.getZeroBased());
+        Medication deletedMedication = patientToDeleteMedication.getMedications().get(
+                INDEX_FIRST_ATTRIBUTE.getZeroBased());
 
         DeleteMedicationCommand deleteMedicationCommand =
                 new DeleteMedicationCommand(INDEX_SECOND_PERSON, INDEX_FIRST_ATTRIBUTE);
@@ -91,7 +92,8 @@ public class DeleteMedicationCommandTest {
         Patient patientToDeleteMedication = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Patient editedPatient = new PersonBuilder(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()))
                 .withMedications().build();
-        Medication deletedMedication = patientToDeleteMedication.getMedications().get(INDEX_FIRST_ATTRIBUTE.getZeroBased());
+        Medication deletedMedication = patientToDeleteMedication.getMedications().get(
+                INDEX_FIRST_ATTRIBUTE.getZeroBased());
 
         DeleteMedicationCommand deleteMedicationCommand =
                 new DeleteMedicationCommand(INDEX_FIRST_PERSON, INDEX_FIRST_ATTRIBUTE);

--- a/src/test/java/seedu/uninurse/logic/commands/DeleteMedicationCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/DeleteMedicationCommandTest.java
@@ -1,0 +1,164 @@
+package seedu.uninurse.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.uninurse.commons.core.Messages.MESSAGE_INVALID_MEDICATION_INDEX;
+import static seedu.uninurse.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static seedu.uninurse.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.uninurse.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.uninurse.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.uninurse.logic.commands.DeleteMedicationCommand.DELETE_MEDICATION_COMMAND_TYPE;
+import static seedu.uninurse.logic.commands.DeleteMedicationCommand.MESSAGE_DELETE_MEDICATION_SUCCESS;
+import static seedu.uninurse.testutil.Assert.assertThrows;
+import static seedu.uninurse.testutil.TypicalIndexes.INDEX_FIRST_ATTRIBUTE;
+import static seedu.uninurse.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.uninurse.testutil.TypicalIndexes.INDEX_SECOND_ATTRIBUTE;
+import static seedu.uninurse.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.uninurse.testutil.TypicalPersons.getTypicalUninurseBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.uninurse.commons.core.index.Index;
+import seedu.uninurse.model.Model;
+import seedu.uninurse.model.ModelManager;
+import seedu.uninurse.model.UninurseBook;
+import seedu.uninurse.model.UserPrefs;
+import seedu.uninurse.model.medication.Medication;
+import seedu.uninurse.model.person.Patient;
+import seedu.uninurse.testutil.PersonBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for {@code DeleteMedicationCommand}.
+ */
+public class DeleteMedicationCommandTest {
+    private final Model model = new ModelManager(getTypicalUninurseBook(), new UserPrefs());
+
+    @Test
+    public void constructor_nullMedicationIndex_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new DeleteMedicationCommand(INDEX_FIRST_PERSON, null));
+    }
+
+    @Test
+    public void constructor_nullPatientIndex_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new DeleteMedicationCommand(null, INDEX_FIRST_ATTRIBUTE));
+    }
+
+    @Test
+    public void execute_nullModel_throwsNullPointerException() {
+        DeleteMedicationCommand deleteMedicationCommand =
+                new DeleteMedicationCommand(INDEX_FIRST_PERSON, INDEX_FIRST_ATTRIBUTE);
+        assertThrows(NullPointerException.class, () -> deleteMedicationCommand.execute(null));
+    }
+
+    @Test
+    void execute_validIndicesUnfilteredList_success() {
+        // use second person in TypicalPersons since there is one medication to delete
+        Patient patientToDeleteMedication = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+        Patient editedPatient = new PersonBuilder(patientToDeleteMedication).withMedications().build();
+        Medication deletedMedication = patientToDeleteMedication.getMedications().get(INDEX_FIRST_ATTRIBUTE.getZeroBased());
+
+        DeleteMedicationCommand deleteMedicationCommand =
+                new DeleteMedicationCommand(INDEX_SECOND_PERSON, INDEX_FIRST_ATTRIBUTE);
+
+        String expectedMessage = String.format(MESSAGE_DELETE_MEDICATION_SUCCESS, INDEX_FIRST_ATTRIBUTE.getOneBased(),
+                editedPatient.getName(), deletedMedication);
+
+        Model expectedModel = new ModelManager(new UninurseBook(model.getUninurseBook()), new UserPrefs());
+        expectedModel.setPerson(patientToDeleteMedication, editedPatient);
+        expectedModel.setPatientOfInterest(editedPatient);
+
+        assertCommandSuccess(deleteMedicationCommand, model, expectedMessage, DELETE_MEDICATION_COMMAND_TYPE,
+                expectedModel);
+    }
+
+    @Test
+    void execute_invalidPatientIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundPatientIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        DeleteMedicationCommand deleteMedicationCommand =
+                new DeleteMedicationCommand(outOfBoundPatientIndex, INDEX_FIRST_ATTRIBUTE);
+
+        assertCommandFailure(deleteMedicationCommand, model, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    void execute_validIndicesFilteredList_success() {
+        // use second person in TypicalPersons since there is one medication to delete
+        showPersonAtIndex(model, INDEX_SECOND_PERSON);
+
+        Patient patientToDeleteMedication = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Patient editedPatient = new PersonBuilder(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()))
+                .withMedications().build();
+        Medication deletedMedication = patientToDeleteMedication.getMedications().get(INDEX_FIRST_ATTRIBUTE.getZeroBased());
+
+        DeleteMedicationCommand deleteMedicationCommand =
+                new DeleteMedicationCommand(INDEX_FIRST_PERSON, INDEX_FIRST_ATTRIBUTE);
+
+        String expectedMessage = String.format(MESSAGE_DELETE_MEDICATION_SUCCESS, INDEX_FIRST_ATTRIBUTE.getOneBased(),
+                editedPatient.getName(), deletedMedication);
+
+        Model expectedModel = new ModelManager(new UninurseBook(model.getUninurseBook()), new UserPrefs());
+        showPersonAtIndex(expectedModel, INDEX_SECOND_PERSON);
+        expectedModel.setPerson(patientToDeleteMedication, editedPatient);
+        expectedModel.setPatientOfInterest(editedPatient);
+
+        assertCommandSuccess(deleteMedicationCommand, model, expectedMessage, DELETE_MEDICATION_COMMAND_TYPE,
+                expectedModel);
+    }
+
+    @Test
+    void execute_invalidPatientIndexFilteredList_throwsCommandException() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+
+        // ensures that outOfBoundIndex is still in bounds of uninurse book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getUninurseBook().getPersonList().size());
+
+        DeleteMedicationCommand deleteMedicationCommand =
+                new DeleteMedicationCommand(outOfBoundIndex, INDEX_FIRST_ATTRIBUTE);
+
+        assertCommandFailure(deleteMedicationCommand, model, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    void execute_invalidMedicationIndex_throwsCommandException() {
+        Patient patient = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Index outOfBoundMedicationIndex = Index.fromOneBased(patient.getMedications().size() + 1);
+        DeleteMedicationCommand deleteMedicationCommand =
+                new DeleteMedicationCommand(INDEX_FIRST_PERSON, outOfBoundMedicationIndex);
+
+        assertCommandFailure(deleteMedicationCommand, model, MESSAGE_INVALID_MEDICATION_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        DeleteMedicationCommand deleteFirstPersonFirstMedication =
+                new DeleteMedicationCommand(INDEX_FIRST_PERSON, INDEX_FIRST_ATTRIBUTE);
+        DeleteMedicationCommand deleteSecondPersonFirstMedication =
+                new DeleteMedicationCommand(INDEX_SECOND_PERSON, INDEX_FIRST_ATTRIBUTE);
+        DeleteMedicationCommand deleteFirstPersonSecondMedication =
+                new DeleteMedicationCommand(INDEX_FIRST_PERSON, INDEX_SECOND_ATTRIBUTE);
+
+        // same object -> returns true
+        assertEquals(deleteFirstPersonFirstMedication, deleteFirstPersonFirstMedication);
+
+        // same values -> returns true
+        DeleteMedicationCommand deleteFirstPersonFirstMedicationCopy =
+                new DeleteMedicationCommand(INDEX_FIRST_PERSON, INDEX_FIRST_ATTRIBUTE);
+        assertEquals(deleteFirstPersonFirstMedication, deleteFirstPersonFirstMedicationCopy);
+
+        // different types -> returns false
+        assertNotEquals(1, deleteFirstPersonFirstMedication);
+
+        // null -> returns false
+        assertNotEquals(null, deleteFirstPersonFirstMedication);
+
+        // different person index -> returns false
+        assertNotEquals(deleteFirstPersonFirstMedication, deleteSecondPersonFirstMedication);
+
+        // different medication index -> returns false
+        assertNotEquals(deleteFirstPersonFirstMedication, deleteFirstPersonSecondMedication);
+    }
+}

--- a/src/test/java/seedu/uninurse/logic/parser/DeleteMedicationCommandParserTest.java
+++ b/src/test/java/seedu/uninurse/logic/parser/DeleteMedicationCommandParserTest.java
@@ -1,0 +1,47 @@
+package seedu.uninurse.logic.parser;
+
+import static seedu.uninurse.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.uninurse.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.uninurse.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.uninurse.testutil.Assert.assertThrows;
+import static seedu.uninurse.testutil.TypicalIndexes.INDEX_FIRST_ATTRIBUTE;
+import static seedu.uninurse.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.uninurse.logic.commands.DeleteMedicationCommand;
+
+/**
+ * Contains unit tests for {@code DeleteMedicationCommandParser}.
+ */
+public class DeleteMedicationCommandParserTest {
+
+    private final DeleteMedicationCommandParser parser = new DeleteMedicationCommandParser();
+
+    @Test
+    public void parse_nullArgs_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> parser.parse(null));
+    }
+
+    @Test
+    public void parse_validArgs_success() {
+        assertParseSuccess(parser, "1 1", new DeleteMedicationCommand(INDEX_FIRST_PERSON, INDEX_FIRST_ATTRIBUTE));
+        assertParseSuccess(parser, " 1 1 ", new DeleteMedicationCommand(INDEX_FIRST_PERSON, INDEX_FIRST_ATTRIBUTE));
+    }
+
+    @Test
+    public void parse_invalidPatientIndex_failure() {
+        assertParseFailure(parser, "a 1",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMedicationCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "0 1",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMedicationCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidMedicationIndex_failure() {
+        assertParseFailure(parser, "1 a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMedicationCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "1 0",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMedicationCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/uninurse/model/medication/MedicationTest.java
+++ b/src/test/java/seedu/uninurse/model/medication/MedicationTest.java
@@ -91,7 +91,7 @@ public class MedicationTest {
 
     @Test
     public void testToString() {
-        String expectedMedicationString = TypicalMedications.TYPICAL_MEDICATION_AMOXICILLIN + " \\| "
+        String expectedMedicationString = TypicalMedications.TYPICAL_MEDICATION_AMOXICILLIN + " | "
                 + TypicalMedications.TYPICAL_DOSAGE_AMOXICILLIN;
         assertEquals(TypicalMedications.MEDICATION_AMOXICILLIN.toString(), expectedMedicationString);
     }

--- a/src/test/java/seedu/uninurse/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/uninurse/testutil/TypicalIndexes.java
@@ -12,4 +12,7 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_TASK = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_TASK = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_TASK = Index.fromOneBased(3);
+    public static final Index INDEX_FIRST_ATTRIBUTE = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND_ATTRIBUTE = Index.fromOneBased(2);
+    public static final Index INDEX_THIRD_ATTRIBUTE = Index.fromOneBased(3);
 }


### PR DESCRIPTION
Closes #190.

Tentatively using `deleteMedication` as the command word before integrating into `DeleteGenericCommand`.
Change model to not update the currently displayed patient list to show all patients after `addMedication` and `deleteMedication`.