### PR TITLE
Fix missing DeleteTagCommandParser case

### DIFF
--- a/src/main/java/seedu/uninurse/logic/parser/UninurseBookParser.java
+++ b/src/main/java/seedu/uninurse/logic/parser/UninurseBookParser.java
@@ -15,6 +15,7 @@ import seedu.uninurse.logic.commands.Command;
 import seedu.uninurse.logic.commands.DeleteConditionCommand;
 import seedu.uninurse.logic.commands.DeleteGenericCommand;
 import seedu.uninurse.logic.commands.DeleteMedicationCommand;
+import seedu.uninurse.logic.commands.DeleteTagCommand;
 import seedu.uninurse.logic.commands.EditGenericCommand;
 import seedu.uninurse.logic.commands.EditMedicationCommand;
 import seedu.uninurse.logic.commands.ExitCommand;
@@ -71,6 +72,9 @@ public class UninurseBookParser {
 
         case AddTagCommand.COMMAND_WORD: // TODO: integrate with AddGenericCommand
             return new AddTagCommandParser().parse(arguments);
+
+        case DeleteTagCommand.COMMAND_WORD: // TODO: integrate with DeleteGenericCommand
+            return new DeleteTagCommandParser().parse(arguments);
 
         case AddConditionCommand.COMMAND_WORD: // TODO: integrate with AddGenericCommand
             return new AddConditionCommandParser().parse(arguments);


### PR DESCRIPTION
I forgot to update `UninurseBookParser` with the `DeleteTagCommandParser` case, which may have caused the failing CI checks.

edit: on second thought, it probably didn't cause the failing CI check but it is still a major bug nonetheless