### PR TITLE
Fix outdated styling of help window and update MESSAGE_USAGE for conditions and tags

### DIFF
--- a/src/main/java/seedu/uninurse/logic/commands/AddConditionCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/AddConditionCommand.java
@@ -2,6 +2,7 @@ package seedu.uninurse.logic.commands;
 
 import static seedu.uninurse.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.uninurse.logic.parser.CliSyntax.PREFIX_CONDITION;
+import static seedu.uninurse.logic.parser.CliSyntax.PREFIX_OPTION_PATIENT_INDEX;
 
 import java.util.List;
 
@@ -18,16 +19,11 @@ import seedu.uninurse.model.person.Patient;
  * Add a medical condition to an existing patient in the patient list.
  */
 public class AddConditionCommand extends AddGenericCommand {
-    // tentative syntax; TODO: integrate with AddGenericCommand
-    public static final String COMMAND_WORD = "addCondition";
-
-    public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Adds a medical condition to the patient identified "
-            + "by the index number used in the last patient listing.\n"
-            + "Parameters: PATIENT_INDEX (must be a positive integer) "
+    public static final String MESSAGE_USAGE = "Command: Add a medical condition to a patient.\n"
+            + "Format: " + COMMAND_WORD + " " + PREFIX_OPTION_PATIENT_INDEX + " PATIENT_INDEX "
             + PREFIX_CONDITION + "CONDITION\n"
-            + "Example: " + COMMAND_WORD
-            + " 2 " + PREFIX_CONDITION + "Hypertension";
+            + "Example: " + COMMAND_WORD + " " + PREFIX_OPTION_PATIENT_INDEX + " 1 "
+            + PREFIX_CONDITION + "Hypertension";
 
     public static final String MESSAGE_ADD_CONDITION_SUCCESS = "New condition added to %1$s: %2$s";
     public static final String MESSAGE_DUPLICATE_CONDITION = "This condition already exists in %1$s's condition list";

--- a/src/main/java/seedu/uninurse/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/AddTagCommand.java
@@ -1,6 +1,7 @@
 package seedu.uninurse.logic.commands;
 
 import static seedu.uninurse.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.uninurse.logic.parser.CliSyntax.PREFIX_OPTION_PATIENT_INDEX;
 import static seedu.uninurse.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.List;
@@ -18,16 +19,10 @@ import seedu.uninurse.model.tag.exceptions.DuplicateTagException;
  * Add a tag to an existing patient in the person list.
  */
 public class AddTagCommand extends AddGenericCommand {
-    // tentative syntax; TODO: integrate with AddGenericCommand
-    public static final String COMMAND_WORD = "addTag";
-
-    public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Adds a tag to the patient identified "
-            + "by the index number used in the last patient listing.\n"
-            + "Parameters: PATIENT_INDEX (must be a positive integer) "
+    public static final String MESSAGE_USAGE = "Command: Add a tag to a patient.\n"
+            + "Format: " + COMMAND_WORD + " " + PREFIX_OPTION_PATIENT_INDEX + " PATIENT_INDEX "
             + PREFIX_TAG + "TAG\n"
-            + "Example: " + COMMAND_WORD
-            + " 2 " + PREFIX_TAG + "high-risk";
+            + "Example: " + COMMAND_WORD + " " + PREFIX_OPTION_PATIENT_INDEX + " 1 " + PREFIX_TAG + "high-risk";
 
     public static final String MESSAGE_ADD_TAG_SUCCESS = "New tag added to %1$s: %2$s";
     public static final String MESSAGE_DUPLICATE_TAG = "This tag already exists in %1$s's tag list";

--- a/src/main/java/seedu/uninurse/logic/commands/DeleteConditionCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/DeleteConditionCommand.java
@@ -2,6 +2,8 @@ package seedu.uninurse.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.uninurse.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.uninurse.logic.parser.CliSyntax.PREFIX_OPTION_CONDITION_INDEX;
+import static seedu.uninurse.logic.parser.CliSyntax.PREFIX_OPTION_PATIENT_INDEX;
 
 import java.util.List;
 
@@ -17,15 +19,11 @@ import seedu.uninurse.model.person.Patient;
  * Deletes a medical condition from a patient identified using its displayed index from the patient list.
  */
 public class DeleteConditionCommand extends DeleteGenericCommand {
-    // tentative syntax; TODO: integrate with DeleteGenericCommand
-    public static final String COMMAND_WORD = "deleteCondition";
-
-    public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the medical condition identified by the index number in the condition list of the patient "
-            + "identified by the index number used in the last patient listing.\n"
-            + "Parameters: PATIENT_INDEX (must be a positive integer) "
-            + "CONDITION_INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1 2";
+    public static final String MESSAGE_USAGE = "Command: Delete a medical condition from a patient.\n"
+            + "Format: " + COMMAND_WORD + " " + PREFIX_OPTION_PATIENT_INDEX + " PATIENT_INDEX "
+            + PREFIX_OPTION_CONDITION_INDEX + " TAG_INDEX\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_OPTION_PATIENT_INDEX + " 1 " + PREFIX_OPTION_CONDITION_INDEX
+            + " 2";
 
     public static final String MESSAGE_DELETE_CONDITION_SUCCESS = "Deleted condition %1$d from %2$s: %3$s";
 

--- a/src/main/java/seedu/uninurse/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/DeleteTagCommand.java
@@ -2,6 +2,8 @@ package seedu.uninurse.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.uninurse.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.uninurse.logic.parser.CliSyntax.PREFIX_OPTION_PATIENT_INDEX;
+import static seedu.uninurse.logic.parser.CliSyntax.PREFIX_OPTION_TAG_INDEX;
 
 import java.util.List;
 
@@ -17,15 +19,11 @@ import seedu.uninurse.model.tag.TagList;
  * Deletes a tag from a patient identified using its displayed index from the patient list.
  */
 public class DeleteTagCommand extends DeleteGenericCommand {
-    // tentative syntax; TODO: integrate with DeleteGenericCommand
-    public static final String COMMAND_WORD = "deleteTag";
-
-    public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the medical tag identified by the index number in the tag list of the patient "
-            + "identified by the index number used in the last patient listing.\n"
-            + "Parameters: PATIENT_INDEX (must be a positive integer) "
-            + "TAG_INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1 2";
+    public static final String MESSAGE_USAGE = "Command: Delete a tag from a patient.\n"
+            + "Format: " + COMMAND_WORD + " " + PREFIX_OPTION_PATIENT_INDEX + " PATIENT_INDEX "
+            + PREFIX_OPTION_TAG_INDEX + " TAG_INDEX\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_OPTION_PATIENT_INDEX + " 1 " + PREFIX_OPTION_TAG_INDEX
+            + " 2";
 
     public static final String MESSAGE_DELETE_TAG_SUCCESS = "Deleted tag %1$d from %2$s: %3$s";
 

--- a/src/main/java/seedu/uninurse/logic/commands/EditConditionCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/EditConditionCommand.java
@@ -3,6 +3,8 @@ package seedu.uninurse.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.uninurse.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.uninurse.logic.parser.CliSyntax.PREFIX_CONDITION;
+import static seedu.uninurse.logic.parser.CliSyntax.PREFIX_OPTION_CONDITION_INDEX;
+import static seedu.uninurse.logic.parser.CliSyntax.PREFIX_OPTION_PATIENT_INDEX;
 
 import java.util.List;
 
@@ -19,18 +21,11 @@ import seedu.uninurse.model.person.Patient;
  * Edits the details of an existing condition for a patient.
  */
 public class EditConditionCommand extends EditGenericCommand {
-    // tentative syntax; TODO: Integrate with EditGenericCommand
-    public static final String COMMAND_WORD = "editCondition";
-
-    public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Edits the condition identified by the index number in the condition list of the patient "
-            + "identified by the index number used in the last patient listing.\n"
-            + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: PATIENT_INDEX (must be a positive integer) "
-            + "CONDITION_INDEX (must be a positive integer) "
-            + PREFIX_CONDITION + "CONDITION\n"
-            + "Example: " + COMMAND_WORD + " 2 " + " 1 "
-            + PREFIX_CONDITION + "Hypertension";
+    public static final String MESSAGE_USAGE = "Command: Edit a medical condition of a patient.\n"
+            + "Format: " + COMMAND_WORD + " " + PREFIX_OPTION_PATIENT_INDEX + " PATIENT_INDEX "
+            + PREFIX_OPTION_CONDITION_INDEX + " CONDITION_INDEX " + PREFIX_CONDITION + "CONDITION\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_OPTION_PATIENT_INDEX + " 1 " + PREFIX_OPTION_CONDITION_INDEX
+            + " 2 " + PREFIX_CONDITION + "Hypertension";
 
     public static final String MESSAGE_EDIT_CONDITION_SUCCESS = "Edited condition %1$d of %2$s:\n"
             + "Before: %3$s\n"

--- a/src/main/java/seedu/uninurse/logic/commands/EditTagCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/EditTagCommand.java
@@ -2,6 +2,8 @@ package seedu.uninurse.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.uninurse.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.uninurse.logic.parser.CliSyntax.PREFIX_OPTION_PATIENT_INDEX;
+import static seedu.uninurse.logic.parser.CliSyntax.PREFIX_OPTION_TAG_INDEX;
 import static seedu.uninurse.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.List;
@@ -19,19 +21,11 @@ import seedu.uninurse.model.tag.exceptions.DuplicateTagException;
  * Edits the details of an existing tag for a patient.
  */
 public class EditTagCommand extends EditGenericCommand {
-    // tentative syntax; TODO: Integrate with EditGenericCommand
-    // remove after integration; use "edit" from EditGenericCommand
-    public static final String COMMAND_WORD = "editTag";
-
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits a tag of a patient.\n"
-            + "Format: " + COMMAND_WORD + " PATIENT_INDEX TAG_INDEX " + PREFIX_TAG + "TAG\n"
-            + "Example: " + COMMAND_WORD + " 2 1 " + PREFIX_TAG + "fall-risk";
-
-    /* use this after integration with EditGenericCommand
     public static final String MESSAGE_USAGE = "Command: Edit a tag of a patient.\n"
             + "Format: " + COMMAND_WORD + " " + PREFIX_OPTION_PATIENT_INDEX + " PATIENT_INDEX "
-            + PREFIX_OPTION_TAG_INDEX + " TAG_INDEX " + PREFIX_TAG + "fall-risk";
-     */
+            + PREFIX_OPTION_TAG_INDEX + " TAG_INDEX " + PREFIX_TAG + "TAG\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_OPTION_PATIENT_INDEX + " 1 " + PREFIX_OPTION_TAG_INDEX
+            + " 2 " + PREFIX_TAG + "fall-risk";
 
     public static final String MESSAGE_EDIT_TAG_SUCCESS = "Edited tag %1$d of %2$s:\n"
             + "Before: %3$s\n"

--- a/src/main/java/seedu/uninurse/logic/commands/ViewPatientCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/ViewPatientCommand.java
@@ -1,6 +1,7 @@
 package seedu.uninurse.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.uninurse.logic.parser.CliSyntax.PREFIX_OPTION_PATIENT_INDEX;
 
 import java.util.List;
 
@@ -19,7 +20,7 @@ public class ViewPatientCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Shows a patient's details identified by the index number used in the displayed patient list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + "Example: " + COMMAND_WORD + " " + PREFIX_OPTION_PATIENT_INDEX + " 1";
 
     public static final String MESSAGE_SUCCESS = "Showing Patient: %1$s";
 

--- a/src/main/java/seedu/uninurse/ui/ModifiedPatientCard.java
+++ b/src/main/java/seedu/uninurse/ui/ModifiedPatientCard.java
@@ -138,7 +138,7 @@ public class ModifiedPatientCard extends UiPart<Region> {
                 .forEach(tag -> tags.getChildren().add(new Label(tag.getValue())));
 
         /* Conditions */
-        conditionHeader.setText("Conditions:");
+        conditionHeader.setText("Conditions");
         if (patient.getConditions().isEmpty()) {
             conditionContainer.getChildren().add(getEmptyConditionBox());
         } else {
@@ -176,7 +176,7 @@ public class ModifiedPatientCard extends UiPart<Region> {
         }
 
         /* Medications */
-        medicationHeader.setText("Medications:");
+        medicationHeader.setText("Medications");
         if (patient.getMedications().isEmpty()) {
             medicationContainer.getChildren().add(getEmptyMedicationBox());
         } else {
@@ -215,7 +215,7 @@ public class ModifiedPatientCard extends UiPart<Region> {
         }
 
         /* Tasks */
-        taskHeader.setText("Tasks:");
+        taskHeader.setText("Tasks");
         if (patient.getTasks().isEmpty()) {
             taskContainer.getChildren().add(getEmptyTaskBox());
         } else {
@@ -252,7 +252,7 @@ public class ModifiedPatientCard extends UiPart<Region> {
         }
 
         /* Remarks */
-        remarkHeader.setText("Remarks:");
+        remarkHeader.setText("Remarks");
         if (patient.getRemarks().isEmpty()) {
             remarkContainer.getChildren().add(getEmptyRemarkBox());
         } else {

--- a/src/main/java/seedu/uninurse/ui/UpdatedPatientCard.java
+++ b/src/main/java/seedu/uninurse/ui/UpdatedPatientCard.java
@@ -93,7 +93,7 @@ public class UpdatedPatientCard extends UiPart<Region> {
                 .forEach(tag -> tags.getChildren().add(new Label(tag.getValue())));
 
         /* Conditions */
-        conditionHeader.setText("Conditions:");
+        conditionHeader.setText("Conditions");
         if (patient.getConditions().isEmpty()) {
             conditionContainer.getChildren().add(getEmptyConditionBox());
         } else {
@@ -105,7 +105,7 @@ public class UpdatedPatientCard extends UiPart<Region> {
         }
 
         /* Medications */
-        medicationHeader.setText("Medications:");
+        medicationHeader.setText("Medications");
         if (patient.getMedications().isEmpty()) {
             medicationContainer.getChildren().add(getEmptyMedicationBox());
         } else {
@@ -117,7 +117,7 @@ public class UpdatedPatientCard extends UiPart<Region> {
         }
 
         /* Tasks */
-        taskHeader.setText("Tasks:");
+        taskHeader.setText("Tasks");
         if (patient.getTasks().isEmpty()) {
             taskContainer.getChildren().add(getEmptyTaskBox());
         } else {
@@ -131,7 +131,7 @@ public class UpdatedPatientCard extends UiPart<Region> {
         }
 
         /* Remarks */
-        remarkHeader.setText("Remarks:");
+        remarkHeader.setText("Remarks");
         if (patient.getRemarks().isEmpty()) {
             remarkContainer.getChildren().add(getEmptyRemarkBox());
         } else {

--- a/src/main/resources/view/HelpWindow.css
+++ b/src/main/resources/view/HelpWindow.css
@@ -1,19 +1,23 @@
-#copyButton, #helpMessage {
+#helpMessage {
+    -fx-text-fill: black;
+}
+
+#copyButton {
     -fx-text-fill: white;
 }
 
 #copyButton {
-    -fx-background-color: dimgray;
+    -fx-background-color: derive(#2e4a8a, 20%);
 }
 
 #copyButton:hover {
-    -fx-background-color: gray;
+    -fx-background-color: derive(#2e4a8a, 50%);
 }
 
 #copyButton:armed {
-    -fx-background-color: darkgray;
+    -fx-background-color: #2e4a8a;
 }
 
 #helpMessageContainer {
-    -fx-background-color: derive(#1d1d1d, 20%);
+    -fx-background-color: white;
 }


### PR DESCRIPTION
Closes #300.

This PR fixes the outdated grey styling of the help window from AB3. It looks like this now:
<img width="564" alt="Screenshot 2022-10-28 at 4 09 42 AM" src="https://user-images.githubusercontent.com/88933129/198388513-c4a170a1-b6aa-4931-b74f-ac03469ebb0e.png">
Hovering over the button lightens the colour, as per the original styling.

I also updated the `MESSAGE_USAGE` for add/delete/edit commands of condition and tag, and partially for focus to it shows the patient index options. I am too sleepy to fix the others properly, so the UG would have to do.

I have also removed the colons from the Conditions, Medications, Tasks and Remarks sections of the `ModifiedPatientCard` and `UpdatedPatientCard`.
