### PR TITLE
Reorganise sections in UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -459,6 +459,12 @@ Examples:
 * `find Betsy` followed by `add -p 2 d/Change dressing on left arm | 12-7-22` adds a task to the 2nd patient in results of the `find` command, on 12th July 2022 0000 hours.
 * `add -p 3 d/Take X-rays | 23-4-22 1345 | 3 weeks` adds a recurring task to the 3rd patient for every 3 weeks starting from 23rd April 2022 1345 hours.
 
+<div markdown="block" class="alert alert-success">
+
+:bulb: **Tip:** You can add multiple medical conditions at once when you first [add a patient](#adding-a-patient-add).
+
+</div>
+
 <br>
 
 ### Editing a task: `edit` `-p` `-d`
@@ -539,7 +545,7 @@ Examples:
 
 You can delete a medical condition of a patient with the `delete` command.
 
-Format: `delete`**`-p PATIENT_INDEX -c CONDITION_INDEX`
+Format: **`delete`**`-p PATIENT_INDEX -c CONDITION_INDEX`
 
 Examples:
 * `list` followed by `delete -p 2 -c 3` deletes the 3rd condition of the 2nd patient in the patient list.
@@ -786,16 +792,17 @@ Format: **`exit`**
 ### Saving the data
 
 UniNurse data are saved in the hard disk automatically after any command that changes the data.
-There is no need to save manually.
+You do not need to save manually.
 
 <br>
 
 ### Editing the data file
 
 UniNurse data are saved as a JSON file `[JAR file location]/data/uninurse.json`.
-Advanced users are welcome to update data directly by editing that data file.
+If you are an advanced user, feel free to update data directly by editing that data file.
 
-<div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
+<div markdown="span" class="alert alert-warning">
+:exclamation: **Caution:**
 If your changes to the data file makes its format invalid, UniNurse will discard all data and start with an empty
 data file at the next run.
 </div>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -842,12 +842,12 @@ the data of your previous UniNurse home folder.
 | **Edit remark**                            | `edit -p PATIENT_INDEX -r REMARK_INDEX r/REMARK`                                                                                         |
 | **Delete remark**                          | `delete -p PATIENT_INDEX -r REMARK_INDEX`                                                                                                |
 | **List all patients**                      | `list`                                                                                                                                   |
+| **Find patient**                           | `find [KEYWORD]… [n/NAME]… [p/PHONE]… [e/EMAIL]… [a/ADDRESS]… [t/TAG]… [c/CONDITION]… [d/TASK_DESCRIPTION]… [m/MEDICATION]… [r/REMARK]…` |
 | **List all details of a patient**          | `focus -p PATIENT_INDEX`                                                                                                                 |
+| **List all patients today**                | `view --today`                                                                                                                           |
 | **List all tasks**                         | `view -p --all`                                                                                                                          |
 | **View all tasks of a patient**            | `view -p PATIENT_INDEX`                                                                                                                  |
-| **List all patients today**                | `view --today`                                                                                                                           |
 | **Listing all tasks for a particular day** | `view DATE`                                                                                                                              |
-| **Find patient**                           | `find [KEYWORD]… [n/NAME]… [p/PHONE]… [e/EMAIL]… [a/ADDRESS]… [t/TAG]… [c/CONDITION]… [d/TASK_DESCRIPTION]… [m/MEDICATION]… [r/REMARK]…` |
 | **Undo last command**                      | `undo`                                                                                                                                   |
 | **Reverse undo command**                   | `redo`                                                                                                                                   |
 | **Clear all patients**                     | `clear`                                                                                                                                  |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -14,27 +14,16 @@ title: User Guide
 
 If your fingers are as quick as your wit, UniNurse helps you to get your patient management tasks done in no time!
 It leverages on a no-frills _Command Line Interface (CLI)_ to give fast typists such as yourself a painless user
-experience.
+experience. 
 
 </div>
 
-
-In UniNurse, every patient has the following details:
-- Name
-- Contact Number
-- Address
-- Email Address 
-- Medical Conditions
-- Medications
-- List of Tasks
-- Remarks
-- Tags
-
 UniNurse offers the following features:
-- Add and edit patient details (as shown above).
-- Find any patient by their details.
-- List all tasks of patients.
-- Show the tasks needed to be done on a specific day. 
+- Add and edit patient details such as name, contact number, medical conditions, etc.
+- Find and filter patients by their details.
+- Add tasks to a patient.
+- Show the tasks to be done on a specific day.
+- Categorize patients using tags.
 
 --------------------------------------------------------------------------------------------------------------------
 
@@ -48,12 +37,66 @@ with UniNurse.
 
 If you are an **experienced user**, you can refer to the [Command Summary](#command-summary) at the end of this guide.
 
+Here are some symbols used throughout this user guide:
+
+| Symbol               | Meaning                                  |
+|----------------------|------------------------------------------|
+| :information_source: | Important things you should take note of |
+| :bulb:               | Useful information                       |
+| :exclamation:        | Warning                                  |
+| :wrench:             | Help with common issues                  |
+
 --------------------------------------------------------------------------------------------------------------------
 
 ### Table of Contents
 
-* Table of Contents
-{:toc}
+1. [Quick start](#quick-start)
+2. [Glossary](#glossary)
+3. [Command format](#command-format)
+4. [Parameter constraints](#parameter-constraints)
+5. [Features](#features)
+   1. [Viewing help: `help`](#viewing-help-help)
+   2. [Modifying patient contact details](#adding-a-patient-add)
+      1. [Adding a patient: `add`](#adding-a-patient-add)
+      2. [Editing a patient's contact details: `edit` `-p`](#editing-a-patients-contact-details-edit--p)
+      3. [Deleting a patient: `delete` `-p`](#deleting-a-patient-delete--p)
+   3. [Modifying tags](#adding-a-tag-add--p)
+      1. [Adding a tag: `add` `-p`](#adding-a-tag-add--p)
+      2. [Editing a tag: `edit` `-p` `-t`](#editing-a-tag-edit--p--t)
+      3. [Deleting a tag: `delete` `-p` `-t`](#deleting-a-tag-delete--p--t)
+   4. [Modifying tasks](#adding-a-task-add--p)
+      1. [Adding a task: `add` `-p`](#adding-a-task-add--p)
+      2. [Editing a task: `edit` `-p` `-d`](#editing-a-task-edit--p--d)
+      3. [Deleting a task: `delete` `-p` `-d`](#deleting-a-task-delete--p--d)
+   5. [Modifying medical conditions](#adding-a-medical-condition-add--p)
+      1. [Adding a medical condition: `add` `-p`](#adding-a-medical-condition-add--p)
+      2. [Editing a medical condition: `edit` `-p` `-c`](#editing-a-medical-condition-edit--p--c)
+      3. [Deleting a medical condition: `delete` `-p` `-c`](#deleting-a-medical-condition-delete--p--c)
+   6. [Modifying medications](#adding-a-medication-add--p)
+      1. [Adding a medication: `add` `-p`](#adding-a-medication-add--p)
+      2. [Editing a medication: `edit` `-p` `-m`](#editing-a-medication-edit--p--m)
+      3. [Deleting a medication: `delete` `-p` `-m`](#deleting-a-medication-delete--p--m)
+   7. [Modifying remarks](#adding-a-remark-add--p)
+      1. [Adding a remark: `add` `-p`](#adding-a-remark-add--p)
+      2. [Editing a remark: `edit` `-p` `-r`](#editing-a-remark-edit--p--r)
+      3. [Deleting a remark: `delete` `-p` `-r`](#deleting-a-remark-delete--p--r)
+   8. [Viewing patients](#listing-all-patients-list)
+      1. [Listing all patients: `list`](#listing-all-patients-list)
+      2. [Finding patients: `find`](#finding-patients-find)
+      3. [Viewing all details of a patient: `focus` `-p`](#viewing-all-details-of-a-patient-focus--p)
+      4. [Listing all patients for today: `view` `--today`](#listing-all-patients-for-today-view---today)
+   9. [Viewing tasks](#listing-all-tasks-view--p---all)
+      1. [Listing all tasks: `view` `-p` `-all`](#listing-all-tasks-view--p---all)
+      2. [Viewing all tasks of a patient: `view` `-p`](#viewing-all-tasks-of-a-patient-view--p)
+      3. [Listing all tasks for a particular day: `view`](#listing-all-tasks-for-a-particular-day-view)
+   10. [Undoing last command: `undo`](#undo-last-command-undo)
+   11. [Reversing undo command: `redo`](#reverse-undo-command-redo)
+   12. [Clearing all entries: `clear`](#clearing-all-entries-clear)
+   13. [Exiting UniNurse](#exiting-uninurse-exit)
+   14. [Saving patients](#saving-the-data)
+   15. [Editing the data file](#editing-the-data-file)
+6. [FAQ](#faq)
+7. [Command summary](#command-summary)
 
 --------------------------------------------------------------------------------------------------------------------
 
@@ -70,9 +113,9 @@ java -version
 3. Move `uninurse.jar` to the folder you want to use as the home folder for UniNurse.
 4. Double-click the file to start UniNurse. A user interface similar to the one below should appear in a few seconds.
 
-<div markdown="block" class="alert alert-info">
+<div markdown="block" class="alert alert-success">
 
-:bulb: **Tip:** The app comes with some sample contacts by default. Type `clear` in the command box to remove them.
+:bulb: **Tip:** The app comes with some sample patients by default. Type `clear` in the command box to remove them.
 
 </div>
 
@@ -82,28 +125,34 @@ java -version
    you can try:
     * **`help`**: Opens the help window.
     * **`add`**`n/Jane Doe p/91234567 e/janed@example.com a/20 Anderson Road, block 123, #01-01`: Adds a
-      patient named `Jane Doe` to your contacts.
-    * **`delete`**`3`: Deletes the 3rd contact shown in the current list.
-    * **`list`**: Lists all contacts.
-    * **`clear`**: Deletes all contacts.
+      patient named `Jane Doe` to your patient list.
+    * **`delete`**`-p 3`: Deletes the 3rd patient shown in the current list.
+    * **`list`**: Lists all patients.
+    * **`clear`**: Deletes all patients shown in the current list.
     * **`exit`**: Exits from UniNurse.
 6. Refer to the [Features](#features) below for details of each command. Alternatively, you may refer to the
    [Command Summary](#command-summary) at the end of this guide.
+
 --------------------------------------------------------------------------------------------------------------------
 
-## Features
+## Glossary
 
-**Before we begin, let us understand the technical terminologies used:**
+**Here are some of the technical terminologies used:**
 
 | Word         | Meaning                                                                                                                                                                                                    |
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Command      | A sentence which the user inputs to                                                                                                                                                                        |
+| Command      | A sentence which the user inputs to.                                                                                                                                                                       |
 | Command word | The first word of every command.                                                                                                                                                                           |
 | Option       | Part of the user input specifying the options for a command, which is preceded by a flag.                                                                                                                  |
 | Flag         | Part of the user input that allows the user to specify the specific options for a command, consisting of a letter preceded by a hyphen. <br> Type of flags: `-p`, `-t`, `-d`, `-m`, `-c`, `-r`.            |
 | Parameter    | Part of the user input consisting of information supplied by the user to UniNurse, which is preceded by a prefix.                                                                                          |
 | Prefix       | Part of the user input that allows the user to specify information for a patient, consisting of a letter preceded by a hyphen. <br> Type of prefixes: `n/`, `p/`, `e/`, `a/`, `t/`, `d/`, `m/`, `c/`, `r/` |
 
+--------------------------------------------------------------------------------------------------------------------
+
+## Command format
+
+_To be cleaned up_
 
 <div markdown="block" class="alert alert-info">
 
@@ -144,11 +193,68 @@ java -version
 
 </div>
 
+Things to add:
+- explain pipe characters
+
+--------------------------------------------------------------------------------------------------------------------
+
+## Parameter constraints
+
+_To be cleaned up_
+
+### `n/NAME`
+
+`NAME` should only contain alphanumeric characters and spaces.
+
+Example: `n/John Doe`
+
+### `p/PHONE`
+
+`PHONE` should only contain numbers, and it should be at least 3 digits long.
+
+Example: `p/91234567`
+
+### `e/EMAIL`
+
+_Use the one from MESSAGE_CONSTRAINTS_
+
+### `a/ADDRESS`
+
+`ADDRESS` accepts any values.
+
+Example:`a/John street, block 123, #01-01`
+
+### `t/TAG`
+
+`TAG` accepts any values.
+
+Example:`t/12-A nursing home`
+
+### `d/TASK_DESCRIPTION | DATE TIME | INTERVAL TIME_PERIOD`
+
+_To be added_
+
+### `c/CONDITION`
+
+`CONDITION` accepts any values.
+
+Example:`c/Parkinson's disease`
+
+### `m/MEDICATION | DOSAGE`
+
+_To be added_
+
+### `r/REMARK`
+
+_To be added_
+
+
+_Clean up Task parameters, some should be put in the feature, while things like date format maybe be put in this section_
 ### Task parameters
 * A task is specified using two pieces of information: `TASK_DESCRIPTION` and `DATE TIME`.
 * `TASK_DESCRIPTION` can be any non-empty string made of alphanumeric characters.
-* `DATE TIME` must be of the form d-M-yy HHmm, but the time is optional. <br> 
-e.g. `2-7-22 1345`, `28-10-22` are valid dates.
+* `DATE TIME` must be of the form d-M-yy HHmm, but the time is optional. <br>
+  e.g. `2-7-22 1345`, `28-10-22` are valid dates.
 * Although time can be omitted, this will result in the task being created with a default time of `0000` hours.
 * `DATE TIME` itself can be omitted as well, this will result in the task being created with a task date and time of 24 hours from the moment of creation.
 * A task can be recurring, i.e if the Task date passes, it will automatically generate the next Task based on the recurrence.
@@ -158,199 +264,195 @@ e.g. `2-7-22 1345`, `28-10-22` are valid dates.
 * Examples of valid `INTERVAL TIME_PERIOD` are: `3 days`, `7 weeks`, `2 months`.
 * Note that while a task can be created without `DATE TIME`, a recurring task must have a `DATE TIME`.
 
-### Viewing help : `help`
+--------------------------------------------------------------------------------------------------------------------
 
-Shows a message explaining how to access the help page.
+## Features
 
-Format: `help`
+<div markdown="block" class="alert alert-success">
 
-![help message](images/helpMessage.png)
-_Help window displayed after running the `help` command_
+:bulb: **Tip:** You can navigate through your command history by using the `↑` and `↓` arrow keys.
+
+:information_source: **Notes:**
+* _Only successful commands are saved in the command history._
+* _Two or more consecutive identical commands are saved once._
+
+</div>
 
 <br>
 
-### Navigate command history: `↑` `↓`
+### Getting help: `help`
 
-Navigate the command history using the `↑` and `↓` arrow keys.
-* `↑` will replace the text in the command box with the previous command.
-* `↓` will replace the text in the command box with the next command. 
-* Only successful commands are saved in the command history.
-* Two or more consecutive equal commands are saved once.
+You can access the help page with the `help` command.
 
-Examples:
-* `find Betsy`, followed by `list`, then followed by `↑` will replace the text in the command box with `list`. Using `↑` again will replace the text in the command box with `find Betsy`. Using `↓` will replace the command box with `list`.
+Format: **`help`**
+
+![help message](images/helpMessage.png)<br>
+_Help window displayed after running the `help` command_
 
 <br>
 
 ### Adding a patient: `add`
 
-Adds a patient to the patient list.
+You can add a patient to the patient list with the `add` command.
 
-Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [d/TASK_DESCRIPTION | <DATE TIME> | <INTERVAL TIME_PERIOD>]… [c/CONDITION]… [t/TAG]… [m/MEDICATION | DOSAGE]… [r/REMARK]…`
+Format: **`add`**`n/NAME p/PHONE e/EMAIL a/ADDRESS [t/TAG]… [d/TASK_DESCRIPTION | <DATE TIME> | <INTERVAL TIME_PERIOD>]… [c/CONDITION]… [m/MEDICATION | DOSAGE]… [r/REMARK]…`
+
+<div markdown="block" class="alert alert-success">
+
+:bulb: **Tip:** You can view the constraints for each parameter in the [Parameter constraints](#parameter-constraints) section.
+
+</div>
+
+<div markdown="block" class="alert alert-info">
+
+:information_source: **Notes:**
+* You cannot add duplicate patients.
+* A patient with the exact same details (e.g. phone number, tags, medications, etc.) are considered duplicates.
+* Patients with the same name but different details are considered to be distinct.
+
+</div>
+
+<div markdown="block" class="alert alert-success">
+
+:bulb: **Tip:** You can add any number of tags, tasks, medical conditions, medications and remarks to a patient.
+
+</div>
 
 Examples:
-* `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 d/Administer 3ml of example medicine | 16-10-22 t/Severe`
-* `add n/Betsy Crowe p/87901234 e/betsy@example.com a/Jane street blk 420 #01-69 d/Change dressing on left arm t/Low Risk`
-* `add n/Tom pitt p/90904213 e/pitts@example.com a/Bourvard street blk 341 #04-17 d/Moniter blood pressure | 23-10-22 1200 | 3 days`
+* `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 d/Administer 3ml of example medicine | 16-10-22 t/severe t/elderly` adds a patient with the following details:
+  * Name: `John Doe`
+  * Phone number: `98765432`
+  * Email: `johnd@example.com`
+  * Address: `John street, block 123, #01-01`
+  * Tasks: `Administer 3ml of example medicine | 16-10-22`
+  * Tags: `elderly`, `severe`
+* `add n/Betsy Crowe c/Dementia c/High blood pressure e/betsy@example.com a/Jane street blk 420 #01-69 p/87901234` adds a patient with the following details:
+  * Name: `Betsy Crowe`
+  * Phone number: `87901234`
+  * Email: `betsy@example.com`
+  * Address: `Jane street blk 420 #01-69`
+  * Medical conditions: `Dementia`, `High blood pressure`
 
 <br>
 
-### Editing a patient’s details : `edit -p`
+### Editing a patient’s contact details: `edit` `-p`
 
-Edits an existing patient in the patient list.
+You can edit the contact details of an existing patient in the patient list with the `edit` command.
 
-Format: `edit -p INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS]`
+Format: `edit -p PATIENT_INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS]`
 
-* Edits the patient at the specified `INDEX`.
-* The index refers to the index number shown in the displayed patient list.
-* The index ***must be a positive integer*** 1, 2, 3, …
-* At least one of the optional fields must be provided.
-* Existing values will be updated to the input values.
+<div markdown="block" class="alert alert-success">
+
+:bulb: **Tip:** You can view the constraints for each parameter in the [Parameter constraints](#parameter-constraints) section.
+
+</div>
+
+<div markdown="block" class="alert alert-info">
+
+:information_source: **Notes:**
+* You cannot edit tags, tasks, medical conditions, medications and remarks with this command.
+* If there are duplicate patients after editing a patient, it will not be edited.
+
+</div>
+
+<div markdown="block" class="alert alert-success">
+
+:bulb: **Tip:** You can refer to the [Table of contents](#table-of-contents) to find the section with the parameter you want to edit.
+
+</div>
 
 Example:
 
-* `edit -p 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st patient to be `91234567` and `johndoe@example.com` respectively.
-* `edit -p 2 n/Betsy Crower t/` Edits the name of the 2nd patient to be `Betsy Crower` and clears all existing tags.
+* `edit -p 1 p/91234567 e/johndoe@example.com` edits the phone number and email address of the 1st patient to be `91234567` and `johndoe@example.com` respectively.
 
 <br>
 
-### Deleting a patient: `delete -p`
+### Deleting a patient: `delete` `-p`
 
-Deletes the specified patient from the patient list.
+You can delete a patient from the patient list with the `delete` command.
 
-Format: `delete -p INDEX`
-
-* Deletes the patient at the specified `INDEX`.
-* The index refers to the index number shown in the displayed patient list.
-* The index **must be a positive integer** 1, 2, 3, …
+Format: `delete -p PATIENT_INDEX`
 
 Examples:
-* `list` followed by `delete -p 2` deletes the 2nd patient in the patient book.
+* `list` followed by `delete -p 2` deletes the 2nd patient in the patient list.
 * `find Betsy` followed by `delete -p 1` deletes the 1st patient in the results of the `find` command.
 
-<br>
+<div markdown="block" class="alert alert-success">
 
-### Listing all patients: `list`
+:bulb: **Tip:** You can use the `undo` command to undo an accidental `delete` command.
 
-Shows a list of all patients.
-
-Format: `list`
+</div>
 
 <br>
 
-### Listing all details of a patient: `focus -p`
+### Adding a tag: `add` `-p`
 
-Shows all details of a specified patient.
+You can add a tag to a patient with the `add` command.
 
-Format: `focus -p PATIENT_INDEX`
+Format: **`add`**`-p PATIENT_INDEX t/TAG`
+
+<div markdown="block" class="alert alert-info">
+
+:information_source: **Notes:**
+* You can only add one tag at a time.
+* You cannot add duplicate tags.
+* Tags are case-sensitive e.g. `high-risk` is distinct from `High-risk`.
+* Tags are always sorted in lexicographical order.
+
+</div>
 
 Examples:
-* `list` followed by `focus -p 2` shows all details of the 2nd patient in the patient book. 
-* `find Betsy` followed by `focus -p 1` shows all details of the 1st patient in the results of the `find` command.
+* `list` followed by `add -p 1 t/high-risk` adds the `high-risk` tag to the 1st patient in the patient list.
+* `find Betsy` followed by `add -p 2 t/high-risk` adds the `high-risk` tag to the 2nd patient in the results of the `find Betsy` command.
+
+<div markdown="block" class="alert alert-success">
+
+:bulb: **Tip:** You can add multiple tags at once when you first [add a patient](#adding-a-patient-add).
+
+</div>
 
 <br>
 
-### Listing all tasks: `view -p --all`
+### Editing a tag: `edit` `-p` `-t`
 
-Shows a list of all tasks to be completed.
+You can edit a tag of a patient with the `edit` command.
 
-Format: `view -p --all`
+Format: **`edit`**`-p PATIENT_INDEX -t TAG_INDEX t/TAG`
+
+<div markdown="block" class="alert alert-info">
+
+:information_source: **Notes:**
+* You can only edit one tag at a time.
+* If there are duplicate tags after editing a tag, it will not be edited.
+
+</div>
 
 Examples:
-
-Suppose the following patients were added.
-
-`add n/John Doe d/Administer 3ml of example medicine`
-
-`add n/Betsy Crowe d/Change dressing on left arm`
-* `view -p --all` will display:
-    * `Administer 3ml of example medicine FOR John Doe`
-    * `Change dressing on left arm FOR Betsy Crowe`
+* `list` followed by `edit -p 2 -t 3 t/high-risk` edits the 3rd tag of the 2nd patient in the patient list to `high-risk`.
+* `find Betsy` followed by `edit -p 1 -t 2 t/high-risk` edits the 2nd tag of the 1st patient in the results of the `find Betsy` command to `high-risk`.
 
 <br>
 
-### View all tasks associated with a patient: `view -p`
+### Deleting a tag: `delete` `-p` `-t`
 
-Shows all the tasks that are associated with the specified patient.
+You can delete a tag of a patient with the `delete` command.
 
-Format: `view -p PATIENT_INDEX`
+Format: **`delete`** `-p PATIENT_INDEX -t TAG_INDEX`
 
 Examples:
-
-Suppose the following patients were added.
-
-`add n/John Doe d/Administer 3ml of example medicine`
-
-`add n/Betsy Crowe d/Change dressing on left arm`
-* `view -p 1` will display:
-    * `Administer 3ml of example medicine`
-* `view -p 2` will display:
-    * `Change dressing on left arm`
+* `list` followed by `delete -p 2 -t 3` deletes the 3rd tag of the 2nd patient in the patient list.
+* `find Betsy` followed by `delete -p 1 -t 2` deletes the 2nd tag of the 1st patient in the results of the `find Betsy` command.
 
 <br>
 
-### Listing all patients for the day: `view --today`
-
-Shows a list of all patients with tasks due today.
-
-Format: `view --today`
-
-<br>
-
-### Listing all tasks for a particular day: `view`
-
-Shows a list of all tasks on a particular day.
-
-Format: `view DATE`
-
-* The DATE **must be of the specified format** dd-MM-yy
-
-Examples:
-* `view 25-12-22` lists the tasks on 25th December 2022
-
-<br>
-
-### Finding patients: `find`
-
-Finds patients whose names contain any of the given keywords.
-
-Format: `find [KEYWORD]… [n/NAME]… [p/PHONE]… [e/EMAIL]… [a/ADDRESS]… [t/TAG]… [c/CONDITION]… [d/TASK_DESCRIPTION]… [m/MEDICATION]… [r/REMARK]…`
-
-* There should be at least one parameter for the command.
-* The search is case-insensitive. e.g `hans` will match `Hans`.
-* The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`.
-* Partial words can be matched e.g. `Han` will match `Hans`.
-* Patients matching at least one keyword in every parameter type will be returned (i.e. AND search for different parameters, OR search for same parameter). In more details,
-  * At least one of the patient's details (name, phone, email, address, tag, condition, task description, or medication) must match with at least one `KEYWORD`.
-  * The patient's name must match at least one `NAME` parameter.
-  * The patient's phone must match at least one `PHONE` parameter.
-  * The patient's email must match at least one `EMAIL` parameter.
-  * The patient's address must match at least one `ADDRESS` parameter.
-  * The patient's tag must match at least one `TAG` parameter.
-  * The patient's condition must match at least one `CONDITION` parameter.
-  * The patient's medication must match at least one `MEDICATION` parameter.
-  * The patient's remarks must match at least one `REMARK` parameter.
-
-Examples:
-* `find jo` returns patients with names `Joe` and `John`, patients with emails `jo@example.com`, and patients with tag `joints`.
-* `find alice meier` returns `Alice Tan` & `Benson Meier`.
-  ![result for 'find alice meier'](images/findAliceMeierResult.png)
-  _Patient list displayed after running the `find alice meier` command_
-* `find key n/John n/Betsy n/Charlie e/@example.com` returns patients who fulfill all conditions below:
-  * The patient's name contains either `John` or `Betsy` or `Charlie`.
-  * The patient's email address must contain `@example.com`.
-  * At least one of the patient's details must contain `key` (e.g., their tag).
-
-<br>
-
-### Adding a task: `add -p`
+### Adding a task: `add` `-p`
 
 Adds a task or recurring task to a patient.
 
 Format: `add -p PATIENT_INDEX d/TASK_DESCRIPTION | <DATE TIME> | <INTERVAL TIME_PERIOD>`
 
 * Adds a task to a patient at the specified `PATIENT_INDEX`.
-* `DATE TIME` and `INTERVAL TIME_PERIOD` must follow the criteria defined in [Task parameter](#Task parameters).
+* `DATE TIME` and `INTERVAL TIME_PERIOD` must follow the criteria defined in [Task parameters](#task-parameters).
 
 Examples:
 * `list` followed by `add -p 1 d/Administer 3ml of example medicine` adds a task to the 1st patient in the patient list.
@@ -359,7 +461,7 @@ Examples:
 
 <br>
 
-### Editing a task: `edit -p -d`
+### Editing a task: `edit` `-p` `-d`
 
 Edits the specified task or recurring task associated with a patient.
 
@@ -377,7 +479,7 @@ Examples:
 
 <br>
 
-### Deleting a task: `delete -p -d`
+### Deleting a task: `delete` `-p` `-d`
 
 Deletes the specified task or recurring task associated with a patient.
 
@@ -392,40 +494,60 @@ Examples:
 
 <br>
 
-### Adding a medical condition: `add -p`
+### Adding a medical condition: `add` `-p`
 
-Format: `add -p PATIENT_INDEX c/CONDITION`
-* Adds a medical condition to a patient at the specified `PATIENT_INDEX`.
+You can add a medical condition to a patient with the `add` command.
+
+Format: **`add`** `-p PATIENT_INDEX c/CONDITION`
+
+<div markdown="block" class="alert alert-info">
+
+:information_source: **Notes:**
+* You can only add one medical condition at a time.
+* You cannot add duplicate medical conditions.
+* Medical conditions are case-sensitive e.g. `diabetes` is distinct from `Diabetes`.
+
+</div>
 
 Examples:
-* `list` followed by `add -p 1 c/Diabetes` adds a condition to the 1st patient in the patient list.
-* `find Betsy` followed by `add -p 2 c/Alzheimer's disease` adds a condition to the 2nd patient in the patient list.
+* `list` followed by `add -p 1 c/Diabetes` adds the `Diabetes` condition to the 1st patient in the patient list.
+* `find Betsy` followed by `add -p 2 c/Alzheimer's disease` adds the `Diabetes` condition to the 2nd patient in the results of the `find Betsy` command.
 
 <br>
 
-### Editing a medical condition: `edit -p -c`
+### Editing a medical condition: `edit` `-p` `-c`
 
-Format: `edit -p PATIENT_INDEX -c CONDITION_INDEX c/CONDITION`
-* Edits the condition at the specified `CONDITION_INDEX` of the patient at the specified `PATIENT_INDEX`.
+You can edit a medical condition of a patient with the `edit` command.
+
+Format: **`edit`**`-p PATIENT_INDEX -c CONDITION_INDEX c/CONDITION`
+
+<div markdown="block" class="alert alert-info">
+
+:information_source: **Notes:**
+* You can only edit one medical condition at a time.
+* If there are duplicate medical conditions after editing a medical condition, it will not be edited.
+
+</div>
 
 Examples:
 * `list` followed by `edit -p 2 -c 3 c/Diabetes` edits the 3rd condition of the 2nd patient in the patient list to `Diabetes`.
-* `find Betsy` followed by `edit -p 1 -c 2 c/Diabetes` edits the 2nd condition of the 1st patient in the patient list to `Diabetes`.
+* `find Betsy` followed by `edit -p 1 -c 2 c/Diabetes` edits the 2nd condition of the 1st patient in the results of the `find Betsy` command to `Diabetes`.
 
 <br>
 
-### Deleting a medical condition: `delete -p -c`
+### Deleting a medical condition: `delete` `-p` `-c`
 
-Format: `delete -p PATIENT_INDEX -c CONDITION_INDEX`
-* Deletes the medical condition at the specified `CONDITION_INDEX` of the patient at the specified `PATIENT_INDEX`.
+You can delete a medical condition of a patient with the `delete` command.
+
+Format: `delete`**`-p PATIENT_INDEX -c CONDITION_INDEX`
 
 Examples:
 * `list` followed by `delete -p 2 -c 3` deletes the 3rd condition of the 2nd patient in the patient list.
-* `find Betsy` followed by `delete -p 1 -c 2` deletes the 2nd condition of the 1st patient in the patient list.
+* `find Betsy` followed by `delete -p 1 -c 2` deletes the 2nd condition of the 1st patient in the results of the `find Betsy` command.
 
 <br>
 
-### Adding a medication: `add -p`
+### Adding a medication: `add` `-p`
 
 Format: `add -p PATIENT_INDEX m/MEDICATION_TYPE | DOSAGE`
 * Adds a medication to a patient at the specified `PATIENT_INDEX`.
@@ -436,7 +558,7 @@ _To be added_
 
 <br>
 
-### Editing a medication: `edit -p -m`
+### Editing a medication: `edit` `-p` `-m`
 
 Format: `edit -p PATIENT_INDEX -m MEDICATION_INDEX m/MEDICATION_TYPE | DOSAGE`
 * Edits the medication at the specified `MEDICATION_INDEX` of the patient at the specified `PATIENT_INDEX`.
@@ -447,7 +569,7 @@ _To be added_
 
 <br>
 
-### Deleting a medication: `delete -p -m`
+### Deleting a medication: `delete` `-p` `-m`
 
 Format: `delete -p PATIENT_INDEX -m MEDICATION_INDEX`
 * Deletes the medication at the specified `MEDICATION_INDEX` of the patient at the specified `PATIENT_INDEX`.
@@ -458,7 +580,7 @@ _To be added_
 
 <br>
 
-### Adding a remark: `add -p`
+### Adding a remark: `add` `-p`
 
 Format: `add -p PATIENT_INDEX r/REMARK`
 * Adds a remark to a patient at the specified `PATIENT_INDEX`.
@@ -469,7 +591,7 @@ _To be added_
 
 <br>
 
-### Editing a remark: `edit -p -r`
+### Editing a remark: `edit` `-p` `-r`
 
 Format: `edit -p PATIENT_INDEX -r REMARK_INDEX r/REMARK`
 * Edits the remark at the specified `REMARK_INDEX` of the patient at the specified `PATIENT_INDEX`.
@@ -480,7 +602,7 @@ _To be added_
 
 <br>
 
-### Deleting a remark: `delete -p -r`
+### Deleting a remark: `delete` `-p` `-r`
 
 Format: `delete -p PATIENT_INDEX -r REMARK_INDEX`
 * Deletes the remark at the specified `REMARK_INDEX` of the patient at the specified `PATIENT_INDEX`.
@@ -491,49 +613,124 @@ _To be added_
 
 <br>
 
-### Adding a tag: `add -p`
+### Listing all patients: `list`
 
-Format: `add -p PATIENT_INDEX t/TAG`
-* Adds a tag to a patient at the specified `PATIENT_INDEX`.
+Shows a list of all patients.
 
-Examples:
-* `list` followed by `add -p 1 t/high-risk` adds a tag to the 1st patient in the patient list.
-* `find Betsy` followed by `add -p 2 t/elderly` adds a tag to the 2nd patient in the patient list.
+Format: `list`
 
 <br>
 
-### Editing a tag: `edit -p -t`
+### Finding patients: `find`
 
+Finds patients whose names contain any of the given keywords.
 
-Format: `edit -p PATIENT_INDEX -t TAG_INDEX t/TAG`
-* Edits the tag at the specified `TAG_INDEX` of the patient at the specified `PATIENT_INDEX`.
+Format: `find [KEYWORD]… [n/NAME]… [p/PHONE]… [e/EMAIL]… [a/ADDRESS]… [t/TAG]… [c/CONDITION]… [d/TASK_DESCRIPTION]… [m/MEDICATION]… [r/REMARK]…`
+
+* There should be at least one parameter for the command.
+* The search is case-insensitive. e.g `hans` will match `Hans`.
+* The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`.
+* Partial words can be matched e.g. `Han` will match `Hans`.
+* Patients matching at least one keyword in every parameter type will be returned (i.e. AND search for different parameters, OR search for same parameter). In more details,
+    * At least one of the patient's details (name, phone, email, address, tag, condition, task description, or medication) must match with at least one `KEYWORD`.
+    * The patient's name must match at least one `NAME` parameter.
+    * The patient's phone must match at least one `PHONE` parameter.
+    * The patient's email must match at least one `EMAIL` parameter.
+    * The patient's address must match at least one `ADDRESS` parameter.
+    * The patient's tag must match at least one `TAG` parameter.
+    * The patient's condition must match at least one `CONDITION` parameter.
+    * The patient's medication must match at least one `MEDICATION` parameter.
+    * The patient's remarks must match at least one `REMARK` parameter.
 
 Examples:
-* `list` followed by `edit -p 2 -t 3 t/high-risk` edits the 3rd tag of the 2nd patient in the patient list to `high-risk`.
-* `find Betsy` followed by `edit -p 1 -t 2 t/high-risk` edits the 2nd tag of the 1st patient in the patient list to `high-risk`.
+* `find jo` returns patients with names `Joe` and `John`, patients with emails `jo@example.com`, and patients with tag `joints`.
+* `find alice meier` returns `Alice Tan` & `Benson Meier`.
+  ![result for 'find alice meier'](images/findAliceMeierResult.png)
+  _Patient list displayed after running the `find alice meier` command_
+* `find key n/John n/Betsy n/Charlie e/@example.com` returns patients who fulfill all conditions below:
+    * The patient's name contains either `John` or `Betsy` or `Charlie`.
+    * The patient's email address must contain `@example.com`.
+    * At least one of the patient's details must contain `key` (e.g., their tag).
 
 <br>
 
-### Deleting a tag: `delete -p -t`
+### Viewing all details of a patient: `focus` `-p`
 
-Format: `delete -p PATIENT_INDEX -t TAG_INDEX`
-* Deletes the tag at the specified `TAG_INDEX` of the patient at the specified `PATIENT_INDEX`.
+Shows all details of a specified patient.
+
+Format: `focus -p PATIENT_INDEX`
 
 Examples:
-* `list` followed by `delete -p 2 -t 3` deletes the 3rd tag of the 2nd patient in the patient list.
-* `find Betsy` followed by `delete -p 1 -t 2` deletes the 2nd tag of the 1st patient in the patient list.
+* `list` followed by `focus -p 2` shows all details of the 2nd patient in the patient book. 
+* `find Betsy` followed by `focus -p 1` shows all details of the 1st patient in the results of the `find` command.
+
+_Add screenshot here_
 
 <br>
 
-### Clearing all entries: `clear`
+### Listing all patients for today: `view` `--today`
 
-Clears all patient entries in the displayed patient list.
+Shows a list of all patients with tasks due today.
 
-Format: `clear`
+Format: `view --today`
+
+<br>
+
+### Listing all tasks: `view` `-p` `--all`
+
+Shows a list of all tasks to be completed.
+
+Format: `view -p --all`
 
 Examples:
-* `list` followed by `clear` will delete all patients.
-* `find Betsy` followed by `clear` deletes all patients in the results of the `find` command.
+
+Suppose the following patients were added.
+
+`add n/John Doe d/Administer 3ml of example medicine`
+
+`add n/Betsy Crowe d/Change dressing on left arm`
+* `view -p --all` will display:
+    * `Administer 3ml of example medicine FOR John Doe`
+    * `Change dressing on left arm FOR Betsy Crowe`
+
+_Add screenshot here_
+
+<br>
+
+### Viewing all tasks of a patient: `view` `-p`
+
+Shows all the tasks that are associated with the specified patient.
+
+Format: `view -p PATIENT_INDEX`
+
+Examples:
+
+Suppose the following patients were added.
+
+`add n/John Doe d/Administer 3ml of example medicine`
+
+`add n/Betsy Crowe d/Change dressing on left arm`
+* `view -p 1` will display:
+    * `Administer 3ml of example medicine`
+* `view -p 2` will display:
+    * `Change dressing on left arm`
+
+_Add screenshot here_
+
+<br>
+
+### Listing all tasks for a particular day: `view`
+
+Shows a list of all tasks on a particular day.
+
+Format: `view DATE`
+
+* The DATE **must be of the specified format** dd-MM-yy
+
+Examples:
+* `view 25-12-22` lists the tasks on 25th December 2022
+
+_Add screenshot here_
 
 <br>
 
@@ -560,11 +757,29 @@ Example:
 
 <br>
 
-### Exiting the program: `exit`
+### Clearing all entries: `clear`
 
-Exits the program.
+You can clear all patient entries in the displayed patient list with the `clear` command.
 
-Format: `exit`
+Format: **`clear`**
+
+Examples:
+* `list` followed by `clear` will delete all patients.
+* `find Betsy` followed by `clear` deletes all patients in the results of the `find Betsy` command.
+
+<div markdown="block" class="alert alert-success">
+
+:bulb: **Tip:** You can use the `undo` command to undo an accidental `clear` command.
+
+</div>
+
+<br>
+
+### Exiting UniNurse: `exit`
+
+You can exit UniNurse with the `exit` command.
+
+Format: **`exit`**
 
 <br>
 
@@ -585,11 +800,6 @@ If your changes to the data file makes its format invalid, UniNurse will discard
 data file at the next run.
 </div>
 
-<br>
-
-### Archiving data files `[coming in v2.0]`
-
-_Details coming soon ..._
 
 --------------------------------------------------------------------------------------------------------------------
 
@@ -607,15 +817,11 @@ the data of your previous UniNurse home folder.
 |--------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
 | **Help**                                   | `help`                                                                                                                                   |
 | **Add patient**                            | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [d/TASK]… [c/CONDITION]… [t/TAG]… [m/MEDICATION]… [r/REMARK]…`                              |
-| **Edit patient**                           | `edit -p INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS]`                                                                          |
-| **Delete patient**                         | `delete -p INDEX`                                                                                                                        |
-| **List all patients**                      | `list`                                                                                                                                   |
-| **List all details of a patient**          | `focus -p PATIENT_INDEX`                                                                                                                 |
-| **List all tasks**                         | `view -p --all`                                                                                                                          |
-| **View all tasks of a patient**            | `view -p PATIENT_INDEX`                                                                                                                  |
-| **List all patients today**                | `view --today`                                                                                                                           |
-| **Listing all tasks for a particular day** | `view DATE`                                                                                                                              |
-| **Find patient**                           | `find [KEYWORD]… [n/NAME]… [p/PHONE]… [e/EMAIL]… [a/ADDRESS]… [t/TAG]… [c/CONDITION]… [d/TASK_DESCRIPTION]… [m/MEDICATION]… [r/REMARK]…` |
+| **Edit patient**                           | `edit -p PATIENT_INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS]`                                                                  |
+| **Delete patient**                         | `delete -p PATIENT_INDEX`                                                                                                                |
+| **Add tag**                                | `add -p PATIENT_INDEX t/TAG`                                                                                                             |
+| **Edit tag**                               | `edit -p PATIENT_INDEX -t TAG_INDEX t/TAG`                                                                                               |
+| **Delete tag**                             | `delete -p PATIENT_INDEX -t TAG_INDEX`                                                                                                   |
 | **Add task**                               | `add -p PATIENT_INDEX d/TASK`                                                                                                            |
 | **Edit task**                              | `edit -p PATIENT_INDEX -d TASK_INDEX d/TASK`                                                                                             |
 | **Delete task**                            | `delete -p PATIENT_INDEX -d TASK_INDEX`                                                                                                  |
@@ -628,11 +834,15 @@ the data of your previous UniNurse home folder.
 | **Add remark**                             | `add -p PATIENT_INDEX r/REMARK`                                                                                                          |
 | **Edit remark**                            | `edit -p PATIENT_INDEX -r REMARK_INDEX r/REMARK`                                                                                         |
 | **Delete remark**                          | `delete -p PATIENT_INDEX -r REMARK_INDEX`                                                                                                |
-| **Add tag**                                | `add -p PATIENT_INDEX t/TAG`                                                                                                             |
-| **Edit tag**                               | `edit -p PATIENT_INDEX -t TAG_INDEX t/TAG`                                                                                               |
-| **Delete tag**                             | `delete -p PATIENT_INDEX -t TAG_INDEX`                                                                                                   |
-| **Clear all patients**                     | `clear`                                                                                                                                  |
+| **List all patients**                      | `list`                                                                                                                                   |
+| **List all details of a patient**          | `focus -p PATIENT_INDEX`                                                                                                                 |
+| **List all tasks**                         | `view -p --all`                                                                                                                          |
+| **View all tasks of a patient**            | `view -p PATIENT_INDEX`                                                                                                                  |
+| **List all patients today**                | `view --today`                                                                                                                           |
+| **Listing all tasks for a particular day** | `view DATE`                                                                                                                              |
+| **Find patient**                           | `find [KEYWORD]… [n/NAME]… [p/PHONE]… [e/EMAIL]… [a/ADDRESS]… [t/TAG]… [c/CONDITION]… [d/TASK_DESCRIPTION]… [m/MEDICATION]… [r/REMARK]…` |
 | **Undo last command**                      | `undo`                                                                                                                                   |
 | **Reverse undo command**                   | `redo`                                                                                                                                   |
+| **Clear all patients**                     | `clear`                                                                                                                                  |
 | **Exit**                                   | `exit`                                                                                                                                   |
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -14,7 +14,7 @@ title: User Guide
 
 If your fingers are as quick as your wit, UniNurse helps you to get your patient management tasks done in no time!
 It leverages on a no-frills _Command Line Interface (CLI)_ to give fast typists such as yourself a painless user
-experience. 
+experience.
 
 </div>
 


### PR DESCRIPTION
Some of the more important changes made:
- updated the `Using this guide` section with a legend explaining the symbols used throughout the guide.
- reformatted the table of contents manually so commands are grouped under sub-headings
- reordered feature sections and command summary to follow table of contents
- edited the add/edit/delete patient/conditions/tags section to use more 2nd person language (please update your own parts for consistency's sake)
- notes about each feature are now displayed in a blue 'notes' box (using bootstraps's info theme)
- added a parameter constraints section (add patient section links to this section)
- tips are contained in a green box (using bootstrap's success theme)
- updated the add/edit/delete patient/conditions/tags sections to explain the examples given
- updated command syntax is the headers such that there are separate code blocks for the command words and the `-p` flags (see #358)
- stated that tags and conditions are case sensitive (see #357).

I have not updated the other features, so they look inconsistent for now.
I did not update the screenshots.

Currently, my edits may override everyone's UG contribution due to reordering, but after everyone edits the inconsistent parts, it should be balanced enough.