### PR TITLE
Fix coding standards for misc commands

### DIFF
--- a/src/main/java/seedu/uninurse/commons/core/Messages.java
+++ b/src/main/java/seedu/uninurse/commons/core/Messages.java
@@ -12,7 +12,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_CONDITION_INDEX = "The condition index provided is invalid";
     public static final String MESSAGE_INVALID_REMARK_INDEX = "The remark index provided is invalid.";
     public static final String MESSAGE_INVALID_TAG_INDEX = "The tag index provided is invalid.";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_TASK = "This task already exists for this patient";
     public static final String MESSAGE_DUPLICATE_CONDITION = "This condition already exists in %1$s's condition list.";
 }

--- a/src/main/java/seedu/uninurse/logic/commands/Command.java
+++ b/src/main/java/seedu/uninurse/logic/commands/Command.java
@@ -7,18 +7,19 @@ import seedu.uninurse.model.Model;
  * Represents a command with hidden internal logic and the ability to be executed.
  */
 public abstract class Command {
-
     /**
      * Executes the command and returns the result message.
      *
-     * @param model {@code Model} which the command should operate on.
+     * @param model The Model which the command should operate on.
      * @return feedback message of the operation result for display
      * @throws CommandException If an error occurs during command execution.
      */
     public abstract CommandResult execute(Model model) throws CommandException;
 
     /**
-     * Returns whether the command is undo-able.
+     * Checks whether the command is undo-able.
+     *
+     * @return true if command is undo-able.
      */
     public boolean isUndoable() {
         return false;

--- a/src/main/java/seedu/uninurse/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/ExitCommand.java
@@ -8,10 +8,10 @@ import seedu.uninurse.model.Model;
 public class ExitCommand extends Command {
     public static final String COMMAND_WORD = "exit";
     public static final String MESSAGE_SUCCESS = "Exiting UniNurse Book as requested ...";
-    public static final CommandType EXIT_COMMAND_TYPE = CommandType.EXIT;
+    public static final CommandType COMMAND_TYPE = CommandType.EXIT;
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_SUCCESS, EXIT_COMMAND_TYPE);
+        return new CommandResult(MESSAGE_SUCCESS, COMMAND_TYPE);
     }
 }

--- a/src/main/java/seedu/uninurse/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/ExitCommand.java
@@ -7,13 +7,11 @@ import seedu.uninurse.model.Model;
  */
 public class ExitCommand extends Command {
     public static final String COMMAND_WORD = "exit";
-
-    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting UniNurse Book as requested ...";
-
+    public static final String MESSAGE_EXIT_SUCCESS = "Exiting UniNurse Book as requested ...";
     public static final CommandType EXIT_COMMAND_TYPE = CommandType.EXIT;
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, EXIT_COMMAND_TYPE);
+        return new CommandResult(MESSAGE_EXIT_SUCCESS, EXIT_COMMAND_TYPE);
     }
 }

--- a/src/main/java/seedu/uninurse/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/ExitCommand.java
@@ -7,11 +7,11 @@ import seedu.uninurse.model.Model;
  */
 public class ExitCommand extends Command {
     public static final String COMMAND_WORD = "exit";
-    public static final String MESSAGE_EXIT_SUCCESS = "Exiting UniNurse Book as requested ...";
+    public static final String MESSAGE_SUCCESS = "Exiting UniNurse Book as requested ...";
     public static final CommandType EXIT_COMMAND_TYPE = CommandType.EXIT;
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_SUCCESS, EXIT_COMMAND_TYPE);
+        return new CommandResult(MESSAGE_SUCCESS, EXIT_COMMAND_TYPE);
     }
 }

--- a/src/main/java/seedu/uninurse/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/FindCommand.java
@@ -16,7 +16,7 @@ public class FindCommand extends Command {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
     public static final String MESSAGE_SUCCESS = "%1$d persons listed!";
-    public static final CommandType FIND_COMMAND_TYPE = CommandType.FIND;
+    public static final CommandType COMMAND_TYPE = CommandType.FIND;
 
     private final PatientMatchPredicate predicate;
 
@@ -29,7 +29,7 @@ public class FindCommand extends Command {
         requireAllNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(String.format(MESSAGE_SUCCESS, model.getFilteredPersonList().size()),
-                FIND_COMMAND_TYPE);
+                COMMAND_TYPE);
     }
 
     @Override

--- a/src/main/java/seedu/uninurse/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/FindCommand.java
@@ -15,7 +15,7 @@ public class FindCommand extends Command {
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
-    public static final String MESSAGE_FIND_SUCCESS = "%1$d persons listed!";
+    public static final String MESSAGE_SUCCESS = "%1$d persons listed!";
     public static final CommandType FIND_COMMAND_TYPE = CommandType.FIND;
 
     private final PatientMatchPredicate predicate;
@@ -28,7 +28,7 @@ public class FindCommand extends Command {
     public CommandResult execute(Model model) {
         requireAllNonNull(model);
         model.updateFilteredPersonList(predicate);
-        return new CommandResult(String.format(MESSAGE_FIND_SUCCESS, model.getFilteredPersonList().size()),
+        return new CommandResult(String.format(MESSAGE_SUCCESS, model.getFilteredPersonList().size()),
                 FIND_COMMAND_TYPE);
     }
 

--- a/src/main/java/seedu/uninurse/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/FindCommand.java
@@ -1,8 +1,7 @@
 package seedu.uninurse.logic.commands;
 
-import static java.util.Objects.requireNonNull;
+import static seedu.uninurse.commons.util.CollectionUtil.requireAllNonNull;
 
-import seedu.uninurse.commons.core.Messages;
 import seedu.uninurse.model.Model;
 import seedu.uninurse.model.person.PatientMatchPredicate;
 
@@ -12,12 +11,11 @@ import seedu.uninurse.model.person.PatientMatchPredicate;
  */
 public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
-
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all patients whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
-
+    public static final String MESSAGE_FIND_SUCCESS = "%1$d persons listed!";
     public static final CommandType FIND_COMMAND_TYPE = CommandType.FIND;
 
     private final PatientMatchPredicate predicate;
@@ -28,10 +26,9 @@ public class FindCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        requireNonNull(model);
+        requireAllNonNull(model);
         model.updateFilteredPersonList(predicate);
-        return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()),
+        return new CommandResult(String.format(MESSAGE_FIND_SUCCESS, model.getFilteredPersonList().size()),
                 FIND_COMMAND_TYPE);
     }
 

--- a/src/main/java/seedu/uninurse/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/HelpCommand.java
@@ -10,10 +10,10 @@ public class HelpCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
             + "Example: " + COMMAND_WORD;
     public static final String MESSAGE_SUCCESS = "Opened help window.";
-    public static final CommandType HELP_COMMAND_TYPE = CommandType.HELP;
+    public static final CommandType COMMAND_TYPE = CommandType.HELP;
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_SUCCESS, HELP_COMMAND_TYPE);
+        return new CommandResult(MESSAGE_SUCCESS, COMMAND_TYPE);
     }
 }

--- a/src/main/java/seedu/uninurse/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/HelpCommand.java
@@ -7,16 +7,13 @@ import seedu.uninurse.model.Model;
  */
 public class HelpCommand extends Command {
     public static final String COMMAND_WORD = "help";
-
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
             + "Example: " + COMMAND_WORD;
-
-    public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
-
+    public static final String MESSAGE_HELP_SUCCESS = "Opened help window.";
     public static final CommandType HELP_COMMAND_TYPE = CommandType.HELP;
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, HELP_COMMAND_TYPE);
+        return new CommandResult(MESSAGE_HELP_SUCCESS, HELP_COMMAND_TYPE);
     }
 }

--- a/src/main/java/seedu/uninurse/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/HelpCommand.java
@@ -9,11 +9,11 @@ public class HelpCommand extends Command {
     public static final String COMMAND_WORD = "help";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
             + "Example: " + COMMAND_WORD;
-    public static final String MESSAGE_HELP_SUCCESS = "Opened help window.";
+    public static final String MESSAGE_SUCCESS = "Opened help window.";
     public static final CommandType HELP_COMMAND_TYPE = CommandType.HELP;
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_HELP_SUCCESS, HELP_COMMAND_TYPE);
+        return new CommandResult(MESSAGE_SUCCESS, HELP_COMMAND_TYPE);
     }
 }

--- a/src/main/java/seedu/uninurse/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/ListCommand.java
@@ -10,13 +10,13 @@ import seedu.uninurse.model.Model;
  */
 public class ListCommand extends Command {
     public static final String COMMAND_WORD = "list";
-    public static final String MESSAGE_LIST_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_SUCCESS = "Listed all persons";
     public static final CommandType LIST_COMMAND_TYPE = CommandType.LIST;
 
     @Override
     public CommandResult execute(Model model) {
         requireAllNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_LIST_SUCCESS, CommandType.LIST);
+        return new CommandResult(MESSAGE_SUCCESS, CommandType.LIST);
     }
 }

--- a/src/main/java/seedu/uninurse/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/ListCommand.java
@@ -1,6 +1,6 @@
 package seedu.uninurse.logic.commands;
 
-import static java.util.Objects.requireNonNull;
+import static seedu.uninurse.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.uninurse.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.uninurse.model.Model;
@@ -10,15 +10,13 @@ import seedu.uninurse.model.Model;
  */
 public class ListCommand extends Command {
     public static final String COMMAND_WORD = "list";
-
-    public static final String MESSAGE_SUCCESS = "Listed all persons";
-
+    public static final String MESSAGE_LIST_SUCCESS = "Listed all persons";
     public static final CommandType LIST_COMMAND_TYPE = CommandType.LIST;
 
     @Override
     public CommandResult execute(Model model) {
-        requireNonNull(model);
+        requireAllNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS, CommandType.LIST);
+        return new CommandResult(MESSAGE_LIST_SUCCESS, CommandType.LIST);
     }
 }

--- a/src/main/java/seedu/uninurse/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/uninurse/logic/commands/ListCommand.java
@@ -11,12 +11,12 @@ import seedu.uninurse.model.Model;
 public class ListCommand extends Command {
     public static final String COMMAND_WORD = "list";
     public static final String MESSAGE_SUCCESS = "Listed all persons";
-    public static final CommandType LIST_COMMAND_TYPE = CommandType.LIST;
+    public static final CommandType COMMAND_TYPE = CommandType.LIST;
 
     @Override
     public CommandResult execute(Model model) {
         requireAllNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS, CommandType.LIST);
+        return new CommandResult(MESSAGE_SUCCESS, COMMAND_TYPE);
     }
 }

--- a/src/main/java/seedu/uninurse/logic/commands/exceptions/CommandException.java
+++ b/src/main/java/seedu/uninurse/logic/commands/exceptions/CommandException.java
@@ -1,15 +1,23 @@
 package seedu.uninurse.logic.commands.exceptions;
 
 /**
- * Represents an error which occurs during execution of a {@link Command}.
+ * Represents an error which occurs during execution of a Command.
  */
 public class CommandException extends Exception {
+    /**
+     * Constructs a new CommandException with the specified detail message.
+     *
+     * @param message The given detail message.
+     */
     public CommandException(String message) {
         super(message);
     }
 
     /**
-     * Constructs a new {@code CommandException} with the specified detail {@code message} and {@code cause}.
+     * Constructs a new CommandException with the specified detail message and cause.
+     *
+     * @param message The given detail message.
+     * @param cause The given cause.
      */
     public CommandException(String message, Throwable cause) {
         super(message, cause);

--- a/src/main/java/seedu/uninurse/logic/parser/Parser.java
+++ b/src/main/java/seedu/uninurse/logic/parser/Parser.java
@@ -4,13 +4,16 @@ import seedu.uninurse.logic.commands.Command;
 import seedu.uninurse.logic.parser.exceptions.ParseException;
 
 /**
- * Represents a Parser that is able to parse user input into a {@code Command} of type {@code T}.
+ * Represents a Parser that is able to parse user input into a Command.
+ * @param <T> The type of the command.
  */
 public interface Parser<T extends Command> {
-
     /**
-     * Parses {@code userInput} into a command and returns it.
-     * @throws ParseException if {@code userInput} does not conform the expected format
+     * Parses the given user input into a command.
+     *
+     * @param userInput The given user input to be parsed.
+     * @return the resulting Command.
+     * @throws ParseException if user input does not conform to the expected format
      */
     T parse(String userInput) throws ParseException;
 }

--- a/src/main/java/seedu/uninurse/logic/parser/Prefix.java
+++ b/src/main/java/seedu/uninurse/logic/parser/Prefix.java
@@ -20,20 +20,20 @@ public class Prefix {
     }
 
     @Override
-    public int hashCode() {
-        return prefix == null ? 0 : prefix.hashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (!(obj instanceof Prefix)) {
+    public boolean equals(Object other) {
+        if (!(other instanceof Prefix)) {
             return false;
         }
-        if (obj == this) {
+        if (other == this) {
             return true;
         }
 
-        Prefix otherPrefix = (Prefix) obj;
-        return otherPrefix.getPrefix().equals(getPrefix());
+        Prefix o = (Prefix) other;
+        return o.getPrefix().equals(prefix);
+    }
+
+    @Override
+    public int hashCode() {
+        return prefix == null ? 0 : prefix.hashCode();
     }
 }

--- a/src/main/java/seedu/uninurse/logic/parser/exceptions/ParseException.java
+++ b/src/main/java/seedu/uninurse/logic/parser/exceptions/ParseException.java
@@ -6,7 +6,6 @@ import seedu.uninurse.commons.exceptions.IllegalValueException;
  * Represents a parse error encountered by a parser.
  */
 public class ParseException extends IllegalValueException {
-
     public ParseException(String message) {
         super(message);
     }

--- a/src/test/java/seedu/uninurse/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/uninurse/logic/LogicManagerTest.java
@@ -65,7 +65,7 @@ public class LogicManagerTest {
     @Test
     public void execute_validCommand_success() throws Exception {
         String listCommand = ListCommand.COMMAND_WORD;
-        assertCommandSuccess(listCommand, ListCommand.MESSAGE_LIST_SUCCESS, model);
+        assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
     }
 
     @Test

--- a/src/test/java/seedu/uninurse/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/uninurse/logic/LogicManagerTest.java
@@ -65,7 +65,7 @@ public class LogicManagerTest {
     @Test
     public void execute_validCommand_success() throws Exception {
         String listCommand = ListCommand.COMMAND_WORD;
-        assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
+        assertCommandSuccess(listCommand, ListCommand.MESSAGE_LIST_SUCCESS, model);
     }
 
     @Test

--- a/src/test/java/seedu/uninurse/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/ExitCommandTest.java
@@ -1,7 +1,6 @@
 package seedu.uninurse.logic.commands;
 
 import static seedu.uninurse.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.uninurse.logic.commands.ExitCommand.MESSAGE_EXIT_SUCCESS;
 
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +13,7 @@ public class ExitCommandTest {
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_SUCCESS,
+        CommandResult expectedCommandResult = new CommandResult(ExitCommand.MESSAGE_SUCCESS,
                 ExitCommand.EXIT_COMMAND_TYPE);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }

--- a/src/test/java/seedu/uninurse/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/ExitCommandTest.java
@@ -14,7 +14,7 @@ public class ExitCommandTest {
     @Test
     public void execute_exit_success() {
         CommandResult expectedCommandResult = new CommandResult(ExitCommand.MESSAGE_SUCCESS,
-                ExitCommand.EXIT_COMMAND_TYPE);
+                ExitCommand.COMMAND_TYPE);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/uninurse/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/ExitCommandTest.java
@@ -1,7 +1,7 @@
 package seedu.uninurse.logic.commands;
 
 import static seedu.uninurse.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.uninurse.logic.commands.ExitCommand.MESSAGE_EXIT_ACKNOWLEDGEMENT;
+import static seedu.uninurse.logic.commands.ExitCommand.MESSAGE_EXIT_SUCCESS;
 
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +14,7 @@ public class ExitCommandTest {
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT,
+        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_SUCCESS,
                 ExitCommand.EXIT_COMMAND_TYPE);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }

--- a/src/test/java/seedu/uninurse/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/FindCommandTest.java
@@ -58,7 +58,7 @@ public class FindCommandTest {
         PatientMatchPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, FindCommand.FIND_COMMAND_TYPE, expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, FindCommand.COMMAND_TYPE, expectedModel);
         assertNotEquals(Collections.emptyList(), model.getFilteredPersonList());
     }
 
@@ -68,7 +68,7 @@ public class FindCommandTest {
         PatientMatchPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, FindCommand.FIND_COMMAND_TYPE, expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, FindCommand.COMMAND_TYPE, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
     }
 

--- a/src/test/java/seedu/uninurse/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/FindCommandTest.java
@@ -2,8 +2,8 @@ package seedu.uninurse.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static seedu.uninurse.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.uninurse.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.uninurse.logic.commands.FindCommand.MESSAGE_FIND_SUCCESS;
 import static seedu.uninurse.testutil.TypicalPersons.CARL;
 import static seedu.uninurse.testutil.TypicalPersons.ELLE;
 import static seedu.uninurse.testutil.TypicalPersons.FIONA;
@@ -20,7 +20,7 @@ import seedu.uninurse.model.UserPrefs;
 import seedu.uninurse.model.person.PatientMatchPredicate;
 
 /**
- * Contains integration tests (interaction with the Model) for {@code FindCommand}.
+ * Contains integration tests (interaction with the Model) for FindCommand.
  */
 public class FindCommandTest {
     private final Model model = new ModelManager(getTypicalUninurseBook(), new UserPrefs());
@@ -55,7 +55,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_zeroKeywords_allPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size());
+        String expectedMessage = String.format(MESSAGE_FIND_SUCCESS, model.getFilteredPersonList().size());
         PatientMatchPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -65,7 +65,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        String expectedMessage = String.format(MESSAGE_FIND_SUCCESS, 3);
         PatientMatchPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);

--- a/src/test/java/seedu/uninurse/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/FindCommandTest.java
@@ -3,7 +3,6 @@ package seedu.uninurse.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.uninurse.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.uninurse.logic.commands.FindCommand.MESSAGE_FIND_SUCCESS;
 import static seedu.uninurse.testutil.TypicalPersons.CARL;
 import static seedu.uninurse.testutil.TypicalPersons.ELLE;
 import static seedu.uninurse.testutil.TypicalPersons.FIONA;
@@ -55,7 +54,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_zeroKeywords_allPersonFound() {
-        String expectedMessage = String.format(MESSAGE_FIND_SUCCESS, model.getFilteredPersonList().size());
+        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, model.getFilteredPersonList().size());
         PatientMatchPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -65,7 +64,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_FIND_SUCCESS, 3);
+        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, 3);
         PatientMatchPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);

--- a/src/test/java/seedu/uninurse/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/HelpCommandTest.java
@@ -14,7 +14,7 @@ public class HelpCommandTest {
     @Test
     public void execute_help_success() {
         CommandResult expectedCommandResult = new CommandResult(HelpCommand.MESSAGE_SUCCESS,
-                HelpCommand.HELP_COMMAND_TYPE);
+                HelpCommand.COMMAND_TYPE);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/uninurse/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/HelpCommandTest.java
@@ -1,7 +1,7 @@
 package seedu.uninurse.logic.commands;
 
 import static seedu.uninurse.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.uninurse.logic.commands.HelpCommand.SHOWING_HELP_MESSAGE;
+import static seedu.uninurse.logic.commands.HelpCommand.MESSAGE_HELP_SUCCESS;
 
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +14,7 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, HelpCommand.HELP_COMMAND_TYPE);
+        CommandResult expectedCommandResult = new CommandResult(MESSAGE_HELP_SUCCESS, HelpCommand.HELP_COMMAND_TYPE);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/uninurse/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/HelpCommandTest.java
@@ -1,7 +1,6 @@
 package seedu.uninurse.logic.commands;
 
 import static seedu.uninurse.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.uninurse.logic.commands.HelpCommand.MESSAGE_HELP_SUCCESS;
 
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +13,8 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_HELP_SUCCESS, HelpCommand.HELP_COMMAND_TYPE);
+        CommandResult expectedCommandResult = new CommandResult(HelpCommand.MESSAGE_SUCCESS,
+                HelpCommand.HELP_COMMAND_TYPE);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/uninurse/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/ListCommandTest.java
@@ -28,14 +28,14 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS,
+        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_LIST_SUCCESS,
                 ListCommand.LIST_COMMAND_TYPE, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS,
+        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_LIST_SUCCESS,
                 ListCommand.LIST_COMMAND_TYPE, expectedModel);
     }
 }

--- a/src/test/java/seedu/uninurse/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/ListCommandTest.java
@@ -29,13 +29,13 @@ public class ListCommandTest {
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
         assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS,
-                ListCommand.LIST_COMMAND_TYPE, expectedModel);
+                ListCommand.COMMAND_TYPE, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
         assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS,
-                ListCommand.LIST_COMMAND_TYPE, expectedModel);
+                ListCommand.COMMAND_TYPE, expectedModel);
     }
 }

--- a/src/test/java/seedu/uninurse/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/uninurse/logic/commands/ListCommandTest.java
@@ -28,14 +28,14 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_LIST_SUCCESS,
+        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS,
                 ListCommand.LIST_COMMAND_TYPE, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_LIST_SUCCESS,
+        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS,
                 ListCommand.LIST_COMMAND_TYPE, expectedModel);
     }
 }


### PR DESCRIPTION
Classes fixed:
* `ExitCommand`
* `HelpCommand`
* `ListCommand`
* `FindCommand`
* `Command`
* `Prefix`
* `ParseException`
* `CommandException`
* `Parser`